### PR TITLE
fixes #30 (XSS vulnerability in gcc output)

### DIFF
--- a/app/scripts/live-edit.js
+++ b/app/scripts/live-edit.js
@@ -57,8 +57,8 @@ window.LiveEdit = (function () {
         });
 
         this.editor.setAnnotations(aceAnnotations);
-
-        this.viewModel.lastGccOutput(result.gccOutput);
+        // Fix XSS issue gcc output
+        this.viewModel.lastGccOutput(this.escapeHtml(result.gccOutput));
         this.viewModel.gccErrorCount(result.stats.error);
         this.viewModel.gccWarningCount(result.stats.warning);
         this.viewModel.gccOptsError(gccOptsErrors.map(function(error) { return error.text; }).join('\n'));


### PR DESCRIPTION
fixes #30 (XSS vulnerability in gcc output):
- Escaped HTML characters from gcc output before passing it to the view model
