### PR TITLE
Fix bug with readOnly parameter of editor.addKeyboardCommand()

### DIFF
--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -159,7 +159,10 @@ window.Editor = (function () {
     };
 
     Editor.prototype.addKeyboardCommand = function (cmdName, keyBindings, execFunc, readOnly) {
-        readOnly = readOnly || true;
+        // If readOnly param is not passed in, then default to true, else coerce the passed in value to boolean and use
+        readOnly = (typeof readOnly === 'undefined') ? true : !!readOnly;
+
+        // http://ace.c9.io/#nav=howto
         this.aceEditor.commands.addCommand({
             name: cmdName,
             bindKey: keyBindings,

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -176,7 +176,8 @@ $(document).ready(function () {
     editor.addKeyboardCommand(
         'compileAndRunShortcut',
         compileShortcut,
-        compile
+        compile,
+        true // the compile command should work in readOnly mode
     );
 
     // Initialize Bootstrap tooltip and popover


### PR DESCRIPTION
Fix the readOnly boolean parameter always being set to true.
