### PR TITLE
fix(closeManPageTab) : Removed bugs related to closing tabs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -166,7 +166,7 @@
                                 <a data-bind="attr: { href: '#man-page-tab-' + $index() }" role="tab" data-toggle="tab">
                                     <span class="glyphicon glyphicon-globe"></span>
                                     &nbsp;<span data-bind="text: tabName"></span>&nbsp;
-                                    <button class="close" data-bind="click: $parent.closeManPageTab">&times;</button>
+                                    <button class="close" data-bind="click: $parent.closeManPageTab, clickBubble: false">&times;</button>
                                 </a>
                             </li>
                             <!-- /ko -->

--- a/app/scripts/sys-view-model.js
+++ b/app/scripts/sys-view-model.js
@@ -82,19 +82,15 @@ window.SysViewModel = (function () {
         self.openManPageTabs = ko.observableArray();
         self.currentActiveTabIndex = ko.observable(-2);
         self.closeManPageTab = function (tab) {
-            var previousTabIndex,
+            var newActiveTabIndex = self.currentActiveTabIndex(),
                 index = self.openManPageTabs.indexOf(tab);
 
             self.openManPageTabs.splice(index, 1);
 
-            if (index === self.currentActiveTabIndex()) {
-                if (index >= 1) {
-                    previousTabIndex = index - 1;
-                } else {
-                    previousTabIndex = -1;
-                }
-                self.currentActiveTabIndex(previousTabIndex);
+            if (index <= newActiveTabIndex) {
+                newActiveTabIndex = newActiveTabIndex - 1;
             }
+            self.currentActiveTabIndex(newActiveTabIndex);
 
         };
 


### PR DESCRIPTION
Changes in sys-view-model.js:
- Removed redundant checks surrounding the update of the currentActiveTabIndex to account for the event of closing a non-active tab.
- Changed the condition to update the activeTabIndex only for the case of closing a tab on the left of an active tab.
- Renamed previousTabIndex to newActiveTabIndex to better reflect the functionality change and initialised with currentActiveIndex(default case)

Changes in index.html:
- Stopped click event bubbling on tab close button to prevent unexpected behavior.

Closes #44
