### PR TITLE
Alias grunt task for running a test server, readme updates

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -496,6 +496,8 @@ module.exports = function (grunt) {
         grunt.task.run('shell:writeGitRecentCommits');
     });
 
+    grunt.registerTask('testserver', ['connect:test:keepalive']);
+
     grunt.registerTask('deploy', 'Deploy the sys project', function(target) {
 
         var targets = ['angraveprod', 'staging'];

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ sysbuild/
     └── spec/
 ```
 
+This project was scaffolded using the [Yeoman webapp generator](https://github.com/yeoman/generator-webapp).
+
 ## Development environment set up ##
 1. [Set up Git](https://help.github.com/articles/set-up-git/) and install [node.js](http://nodejs.org/). Node's package manager ([npm](https://www.npmjs.org/)) comes bundled.
 
@@ -58,6 +60,9 @@ because of the [location npm installs global packages](https://www.npmjs.org/doc
 
 * Run tests.  
   `grunt test`
+
+* Run a local test server, to run the tests in a browser. Navigate to `http://localhost:9001` after running the following.  
+  `grunt testserver`
 
 ## Contributing ##
 1. Make sure your fork is up to date with the upstream repository. See https://help.github.com/articles/syncing-a-fork/.  


### PR DESCRIPTION
1) Add an alias grunt task for running a test server
2) Update readme with the test server command
3) Reference the yeoman webapp generator in the readme to show how the project was created.
