### PR TITLE
Fixed bug with nav bar in playground mode

### DIFF
--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -8,29 +8,48 @@ window.Router = (function () {
         /* jshint newcap: false */
         var viewModel = SysViewModel.getInstance();
 
-        var populateChapters = function () {
-            var jqxhr;
-            if (viewModel.chapters().length === 0) {
-                // Load chapters
-                jqxhr = $.getJSON('sysassets/sys.min.json', function (data) {
-                    viewModel.chapters(data.chapters);
-                });
-            } else {
-                // Chapters have already been loaded, so request cannot fail
-                jqxhr = {
-                    done: function (cb) {
-                        if (cb) {
-                            cb();
+        var populateChapters = (function(){
+            var previouslyFailed = false;
+            return function () {
+                var jqxhr;
+                if (previouslyFailed){
+                    // Chapter load already failed, don't try again
+                    jqxhr = {
+                        done: function (){
+                            return this;
+                        },
+                        fail: function (cb){
+                            if (cb){
+                                cb();
+                            }
+                            return this;
                         }
-                        return this;
-                    },
-                    fail: function () {
-                        return this;
-                    }
-                };
-            }
-            return jqxhr;
-        };
+                    };
+                } else if (viewModel.chapters().length === 0) {
+                    // Load chapters
+                    jqxhr = $.getJSON('sysassets/sys.min.json', function (data) {
+                        viewModel.chapters(data.chapters);
+                    }).fail(function(){
+                        // Getting file failed, don't try again
+                        previouslyFailed = true;
+                    });
+                } else {
+                    // Chapters have already been loaded, so request cannot fail
+                    jqxhr = {
+                        done: function (cb) {
+                            if (cb) {
+                                cb();
+                            }
+                            return this;
+                        },
+                        fail: function () {
+                            return this;
+                        }
+                    };
+                }
+                return jqxhr;
+            };
+        })();
 
         var populateCurrentNavigation = function (chapterIdx, sectionIdx, activityIdx) {
             var chapter = viewModel.chapters()[chapterIdx];


### PR DESCRIPTION
This closes #57 

The file `router.js` is in charge of loading relevant content and performing relevant actions when a user navigates to a page within the site. The function `populateChapters()` was called when loading lesson content but not called when just going to the playground. Including this function call within the playground route resolved the issue.

I didn't feel the need to use the asynchronous syntax (`populateChapters().done(function(){...});`) since none of the playground content is dependent on the lessons. However, not including this in the asynchronous format may have consequences that I haven't considered.
