### PR TITLE
Fix the editor settings popover dismissing when clicking in it

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -197,7 +197,7 @@
                                         </div>
                                         <div class="col-md-2">
                                             <a href="#" tabindex="0" id="editor-settings-btn" type="button" class="btn btn-default btn-sm center-block"
-                                               data-toggle="popover" data-trigger="focus" data-container="body" data-html="true" data-placement="bottom">
+                                               data-toggle="popover" data-trigger="manual" data-container="body" data-html="true" data-placement="bottom">
                                                 <span class="glyphicon glyphicon-cog"></span> Settings
                                             </a>
                                         </div>

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -108,6 +108,24 @@ window.Editor = (function () {
         $body.on('change', '#' + self.elementIdPrefix + 'ace-show-invisibles-checkbox', function () {
             self.aceEditor.setShowInvisibles(this.checked);
         });
+
+        // The following three click handlers achieve toggling the settings popover when clicking the settings button
+        // and hiding it when clicking anywhere outside it.
+        $body.on('click', function () {
+            $settingsPopover.popover('hide');
+        });
+
+        // TODO: The .popover selector will select all popovers,
+        // and so a click on any popover in the body with trigger !== "focus" will call this handler.
+        // This works for now, but may create problems in the future.
+        $body.on('click', '.popover', function (e) {
+            e.stopPropagation();
+        });
+
+        $settingsPopover.on('click', function (e) {
+            $settingsPopover.popover('toggle');
+            e.stopPropagation();
+        });
     }
 
     Editor.prototype.setTheme = function (theme) {


### PR DESCRIPTION
The editor settings popover closes if the user clicks inside it, even when clicking the check boxes. This is actually true for all popovers (which have trigger set to `focus`).

The solution to this is to set the popover trigger to `manual`, and then toggle the popover when the "settings" button is clicked. Also, the popover is dismissed when the user clicks anywhere but the popover itself.
