### PR TITLE
Fix #81 refresh upon pressing enter in editor font size box

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -189,7 +189,6 @@ $(document).ready(function () {
         });
 
     $('#editor-opts-container').find('form').submit(function (e) {
-        //return false;
         e.preventDefault();
         e.stopPropagation();
     });

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -188,8 +188,8 @@ $(document).ready(function () {
             e.preventDefault();
         });
 
-    $('#editor-opts-container').find('form').submit(function (e) {
-        e.preventDefault();
+    $('#editor-opts-container').find('form').submit(function () {
+        return false;
     });
 
     $('#download-file-btn').click(function () {

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -188,8 +188,10 @@ $(document).ready(function () {
             e.preventDefault();
         });
 
-    $('#editor-opts-container').find('form').submit(function () {
-        return false;
+    $('#editor-opts-container').find('form').submit(function (e) {
+        //return false;
+        e.preventDefault();
+        e.stopPropagation();
     });
 
     $('#download-file-btn').click(function () {


### PR DESCRIPTION
Fixes #81. Verified on OS X 10.10, Chrome 41 and Safari 8.0.3.