### PR TITLE
Issue #77: Save editor configuration settings in browser

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -359,6 +359,7 @@
         <!-- build:js({app,.tmp}) scripts/main.js -->
         <script src="scripts/ga-tracking.js"></script>
         <script src="scripts/sys-view-model.js"></script>
+        <script src="scripts/preferences.js"></script>
         <script src="scripts/jor1k-master.js"></script>
         <script src="scripts/expect-tty.js"></script>
         <script src="scripts/editor.js"></script>

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -27,7 +27,7 @@ window.Editor = (function () {
             self.useLocalStorage = false;
         }
 
-        if(self.useLocalStorage) {
+        if (self.useLocalStorage) {
 
             var autoIndent = localStorage.getItem('autoindent');
             var showInvisibles = localStorage.getItem('showinvisibles');
@@ -35,24 +35,24 @@ window.Editor = (function () {
             var theme = localStorage.getItem('theme');
             var fontSize = localStorage.getItem('fontsize');
 
-            if(autoIndent !== null) {
+            if (autoIndent !== null) {
                 self.backgroundAutoIndent = (autoIndent === 'true');
             }
 
-            if(showInvisibles !== null) {
+            if (showInvisibles !== null) {
                 self.aceEditor.setShowInvisibles(showInvisibles === 'true');
             }
 
-            if(highlightLine !== null) {
+            if (highlightLine !== null) {
                 self.aceEditor.setHighlightActiveLine(highlightLine === 'true');
             }
 
-            if(theme !== null) {
+            if (theme !== null) {
                 self.setTheme(theme);
                 self.viewModel.aceTheme(theme);
             }
 
-            if(fontSize !== null) {
+            if (fontSize !== null) {
                 self.setFontSize(fontSize + 'px');
                 self.viewModel.aceFontSize(fontSize);
             }
@@ -67,14 +67,14 @@ window.Editor = (function () {
         // automatically change theme upon selection
         self.viewModel.aceTheme.subscribe(function (newTheme) {
             self.setTheme(newTheme);
-            if(self.useLocalStorage) {
+            if (self.useLocalStorage) {
                 localStorage.setItem('theme', newTheme);
             }
         });
 
         self.viewModel.aceFontSize.subscribe(function (newFontSize) {
             self.setFontSize(newFontSize + 'px');
-            if(self.useLocalStorage) {
+            if (self.useLocalStorage) {
                 localStorage.setItem('fontsize', newFontSize);
             }
         });
@@ -147,21 +147,21 @@ window.Editor = (function () {
         var $body = $('body');
         $body.on('change', '#' + self.elementIdPrefix + 'autoindent-checkbox', function () {
             self.backgroundAutoIndent = this.checked;
-            if(self.useLocalStorage) {
+            if (self.useLocalStorage) {
                 localStorage.setItem('autoindent', this.checked);
             }
         });
 
         $body.on('change', '#' + self.elementIdPrefix + 'ace-highlight-active-lines-checkbox', function () {
             self.aceEditor.setHighlightActiveLine(this.checked);
-            if(self.useLocalStorage) {
+            if (self.useLocalStorage) {
                 localStorage.setItem('highlightline', this.checked);
             }
         });
 
         $body.on('change', '#' + self.elementIdPrefix + 'ace-show-invisibles-checkbox', function () {
             self.aceEditor.setShowInvisibles(this.checked);
-            if(self.useLocalStorage) {
+            if (self.useLocalStorage) {
                 localStorage.setItem('showinvisibles', this.checked);
             }
         });

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -22,14 +22,14 @@ window.Editor = (function () {
         self.preferences = Preferences.getInstance('editor');
 
         var autoIndent = self.preferences.getItem('autoindent', 'true');
+        var highlightLine = self.preferences.getItem('highlightline', 'true');
         var showInvisibles = self.preferences.getItem('showinvisibles', 'false');
-        var highlightLine = self.preferences.getItem('highlightline', 'false');
         var theme = self.preferences.getItem('theme', self.viewModel.aceTheme());
         var fontSize = self.preferences.getItem('fontsize', 12);
 
         self.backgroundAutoIndent = (autoIndent === 'true');
-        self.aceEditor.setShowInvisibles(showInvisibles === 'true');
         self.aceEditor.setHighlightActiveLine(highlightLine === 'true');
+        self.aceEditor.setShowInvisibles(showInvisibles === 'true');
         self.setTheme(theme);
         self.viewModel.aceTheme(theme);
         self.setFontSize(fontSize + 'px');

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -21,10 +21,10 @@ window.Editor = (function () {
 
         // check if local storage supported
         try {
-             self.useLocalStorage = (localStorage !== 'undefined');
+            self.useLocalStorage = (localStorage !== 'undefined');
         } catch (e) {
-             // error accessing local storage (user may have blocked access)
-             self.useLocalStorage = false;
+            // error accessing local storage (user may have blocked access)
+            self.useLocalStorage = false;
         }
 
         if(self.useLocalStorage) {
@@ -36,15 +36,15 @@ window.Editor = (function () {
             var fontSize = localStorage.getItem('fontsize');
 
             if(autoIndent !== null) {
-                self.backgroundAutoIndent = (autoIndent == 'true');
+                self.backgroundAutoIndent = (autoIndent === 'true');
             }
 
             if(showInvisibles !== null) {
-                self.aceEditor.setShowInvisibles(showInvisibles == 'true');
+                self.aceEditor.setShowInvisibles(showInvisibles === 'true');
             }
 
             if(highlightLine !== null) {
-                self.aceEditor.setHighlightActiveLine(highlightLine == 'true');
+                self.aceEditor.setHighlightActiveLine(highlightLine === 'true');
             }
 
             if(theme !== null) {

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -18,7 +18,6 @@ window.Editor = (function () {
         self.setMode('c_cpp');
         self.aceEditor.getSession().setTabSize(4);
         self.aceEditor.getSession().setUseSoftTabs(true);
-        self.backgroundAutoIndent = false;
 
         // check if local storage supported
         try {

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -29,8 +29,6 @@ window.Editor = (function () {
 
         if(self.useLocalStorage) {
 
-            self.useLocalStorage = true;
-
             var autoIndent = localStorage.getItem('autoindent');
             var showInvisibles = localStorage.getItem('showinvisibles');
             var highlightLine = localStorage.getItem('highlightline');

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -22,8 +22,8 @@ window.Editor = (function () {
         self.preferences = Preferences.getInstance('editor');
 
         var autoIndent = self.preferences.getItem('autoindent', 'true');
-        var showInvisibles = self.preferences.getItem('showinvisibles', 'true');
-        var highlightLine = self.preferences.getItem('highlightline', 'true');
+        var showInvisibles = self.preferences.getItem('showinvisibles', 'false');
+        var highlightLine = self.preferences.getItem('highlightline', 'false');
         var theme = self.preferences.getItem('theme', self.viewModel.aceTheme());
         var fontSize = self.preferences.getItem('fontsize', 12);
 

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -21,7 +21,12 @@ window.Editor = (function () {
         self.backgroundAutoIndent = false;
 
         // check if local storage supported
-        self.useLocalStorage = (typeof(Storage) !== 'undefined');
+        try {
+             self.useLocalStorage = (localStorage !== 'undefined');
+        } catch (e) {
+             // error accessing local storage (user may have blocked access)
+             self.useLocalStorage = false;
+        }
 
         if(self.useLocalStorage) {
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -189,7 +189,6 @@ $(document).ready(function () {
         });
 
     $('#editor-opts-container').find('form').submit(function (e) {
-        //return false;
         e.preventDefault();
         e.stopPropagation();
     });

--- a/app/scripts/preferences.js
+++ b/app/scripts/preferences.js
@@ -1,0 +1,98 @@
+
+window.Preferences = (function () {
+    'use strict';
+    var instance;
+    var namedinstances = [];
+
+    function Preferences() {
+        var self = this;
+
+        // check if local storage supported
+        try {
+            self.useLocalStorage = (localStorage !== 'undefined');
+        } catch (e) {
+            // error accessing local storage (user may have blocked access)
+            console.log(e);
+            self.useLocalStorage = false;
+        }
+
+        self.setItem = function (key, value) {
+            if (self.useLocalStorage) {
+                try {
+                    localStorage.setItem(key, value);
+                } catch (e) {
+                    // error modifying local storage (out of space?)
+                    console.log(e);
+                }
+            }
+        };
+
+        self.getItem = function (key, defaultValue) {
+            if (self.useLocalStorage) {
+                try {
+                    var result = localStorage.getItem(key);
+                    return (result !== null ? result : defaultValue);
+                } catch (e) {
+                    // error reading from local storage
+                    console.log(e);
+                    return defaultValue;
+                }
+            } else {
+                return defaultValue;
+            }
+        };
+
+        self.removeItem = function (key) {
+            if (self.useLocalStorage) {
+                try {
+                    localStorage.removeItem(key);
+                } catch (e) {
+                    // error modifying local storage
+                    console.log(e);
+                }
+            }
+        };
+
+        self.clear = function () {
+            if (self.useLocalStorage) {
+                try {
+                    localStorage.clear();
+                } catch (e) {
+                    // error modifying local storage
+                    console.log(e);
+                }
+            }
+        };
+    }
+
+    function NamedPreferences(namespace, preferenceManager) {
+        var self = this;
+        var manager = preferenceManager;
+        var prefix = namespace;
+
+        self.setItem = function (key, value) {
+            manager.setItem(prefix + '/' + key, value);
+        };
+
+        self.getItem = function (key, defaultValue) {
+            return manager.getItem(prefix + '/' + key, defaultValue);
+        };
+
+        self.removeItem = function (key) {
+            manager.removeItem(prefix + '/' + key);
+        };
+    }
+
+    return {
+        getInstance: function (namespace) {
+            if (!instance) {
+                instance = new Preferences();
+                instance.constructor = null;
+            }
+            if (!namedinstances[namespace]) {
+                namedinstances[namespace] = new NamedPreferences(namespace, instance);
+            }
+            return namedinstances[namespace];
+        }
+    };
+})();

--- a/app/scripts/preferences.js
+++ b/app/scripts/preferences.js
@@ -67,21 +67,21 @@ window.Preferences = (function () {
 
     function NamedPreferences(namespace, preferenceManager) {
         var self = this;
-        var manager = preferenceManager;
-        var prefix = namespace;
-
-        self.setItem = function (key, value) {
-            manager.setItem(prefix + '/' + key, value);
-        };
-
-        self.getItem = function (key, defaultValue) {
-            return manager.getItem(prefix + '/' + key, defaultValue);
-        };
-
-        self.removeItem = function (key) {
-            manager.removeItem(prefix + '/' + key);
-        };
+        self.manager = preferenceManager;
+        self.prefix = 'preferences/' + namespace;
     }
+
+    NamedPreferences.prototype.setItem = function (key, value) {
+        this.manager.setItem(this.prefix + '/' + key, value);
+    };
+
+    NamedPreferences.prototype.getItem = function (key, defaultValue) {
+        return this.manager.getItem(this.prefix + '/' + key, defaultValue);
+    };
+
+    NamedPreferences.prototype.removeItem = function (key) {
+        this.manager.removeItem(this.prefix + '/' + key);
+    };
 
     return {
         getInstance: function (namespace) {

--- a/app/scripts/preferences.js
+++ b/app/scripts/preferences.js
@@ -15,55 +15,55 @@ window.Preferences = (function () {
             console.log(e);
             self.useLocalStorage = false;
         }
+    }
 
-        self.setItem = function (key, value) {
-            if (self.useLocalStorage) {
-                try {
-                    localStorage.setItem(key, value);
-                } catch (e) {
-                    // error modifying local storage (out of space?)
-                    console.log(e);
-                }
+    Preferences.prototype.setItem = function (key, value) {
+        if (this.useLocalStorage) {
+            try {
+                localStorage.setItem(key, value);
+            } catch (e) {
+                // error modifying local storage (out of space?)
+                console.log(e);
             }
-        };
+        }
+    };
 
-        self.getItem = function (key, defaultValue) {
-            if (self.useLocalStorage) {
-                try {
-                    var result = localStorage.getItem(key);
-                    return (result !== null ? result : defaultValue);
-                } catch (e) {
-                    // error reading from local storage
-                    console.log(e);
-                    return defaultValue;
-                }
-            } else {
+    Preferences.prototype.getItem = function (key, defaultValue) {
+        if (this.useLocalStorage) {
+            try {
+                var result = localStorage.getItem(key);
+                return (result !== null ? result : defaultValue);
+            } catch (e) {
+                // error reading from local storage
+                console.log(e);
                 return defaultValue;
             }
-        };
+        } else {
+            return defaultValue;
+        }
+    };
 
-        self.removeItem = function (key) {
-            if (self.useLocalStorage) {
-                try {
-                    localStorage.removeItem(key);
-                } catch (e) {
-                    // error modifying local storage
-                    console.log(e);
-                }
+    Preferences.prototype.removeItem = function (key) {
+        if (this.useLocalStorage) {
+            try {
+                localStorage.removeItem(key);
+            } catch (e) {
+                // error modifying local storage
+                console.log(e);
             }
-        };
+        }
+    };
 
-        self.clear = function () {
-            if (self.useLocalStorage) {
-                try {
-                    localStorage.clear();
-                } catch (e) {
-                    // error modifying local storage
-                    console.log(e);
-                }
+    Preferences.prototype.clear = function () {
+        if (this.useLocalStorage) {
+            try {
+                localStorage.clear();
+            } catch (e) {
+                // error modifying local storage
+                console.log(e);
             }
-        };
-    }
+        }
+    };
 
     function NamedPreferences(namespace, preferenceManager) {
         var self = this;


### PR DESCRIPTION
To save settings, I initialize the browser's local storage (after first checking if it's supported) and read/write to it upon setting changes. If local storage is not supported, then we just use default settings like before.

Closes #77.