### PR TITLE
Issue #70: Added xdomain support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -387,13 +387,6 @@ module.exports = function (grunt) {
                 cwd: 'bower_components/jor1k/',
                 src: ['**', '!.git'],
                 dest: '<%= config.app %>/jor1k/'
-            },
-            sysassets: {
-                expand: true,
-                dot: true,
-                cwd: '<%= config.app %>/sysassets/',
-                src: ['chapters/**', '**/*.min.json'],
-                dest: '<%= config.dist %>/sysassets/'
             }
         },
 
@@ -523,8 +516,6 @@ module.exports = function (grunt) {
             grunt.log.error('Please specify a valid target. Valid targets are: ' + targets.join(', ') + '.');
             return false;
         }
-
-        grunt.task.run('copy:sysassets');
 
         grunt.config('buildcontrol', {
             options: buildcontrolConfig.options,

--- a/app/index.html
+++ b/app/index.html
@@ -325,6 +325,7 @@
         <script src="../bower_components/sammy/lib/sammy.js"></script>
         <script src="../bower_components/videojs/dist/video-js/video.js"></script>
         <script src="../bower_components/typeahead.js/dist/typeahead.bundle.js"></script>
+        <script src="../bower_components/xdomain/dist/xdomain.min.js" slave="http://angrave.github.io/sysassets/proxy.html"></script>
         <!-- endbower -->
         <script src="../bower_components/marked/lib/marked.js"></script>
         <script src="../bower_components/ace-builds/src-min-noconflict/ace.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -325,7 +325,7 @@
         <script src="../bower_components/sammy/lib/sammy.js"></script>
         <script src="../bower_components/videojs/dist/video-js/video.js"></script>
         <script src="../bower_components/typeahead.js/dist/typeahead.bundle.js"></script>
-        <script src="../bower_components/xdomain/dist/xdomain.min.js" slave="http://angrave.github.io/sysassets/proxy.html"></script>
+        <script src="../bower_components/xdomain/dist/xdomain.min.js"></script>
         <!-- endbower -->
         <script src="../bower_components/marked/lib/marked.js"></script>
         <script src="../bower_components/ace-builds/src-min-noconflict/ace.js"></script>
@@ -358,6 +358,7 @@
         <!-- endbuild -->
 
         <!-- build:js({app,.tmp}) scripts/main.js -->
+        <script src="scripts/xdomain.js"></script>
         <script src="scripts/ga-tracking.js"></script>
         <script src="scripts/sys-view-model.js"></script>
         <script src="scripts/jor1k-master.js"></script>

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -56,7 +56,7 @@ $(document).ready(function () {
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         limit: 10,
         prefetch: {
-            url: 'sysassets/man_pages/sys_man_page_index.min.json'
+            url: 'http://angrave.github.io/sysassets/man_pages/sys_man_page_index.min.json'
         }
     });
 

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -56,7 +56,7 @@ $(document).ready(function () {
         queryTokenizer: Bloodhound.tokenizers.whitespace,
         limit: 10,
         prefetch: {
-            url: 'http://angrave.github.io/sysassets/man_pages/sys_man_page_index.min.json'
+            url: 'http://cs-education.github.io/sysassets/man_pages/sys_man_page_index.min.json'
         }
     });
 
@@ -67,7 +67,7 @@ $(document).ready(function () {
     var getManPageTabData = function (manPage) {
         var name = manPage.name;
         var section = manPage.section;
-        var url = 'https://angrave.github.io/sysassets/man_pages/html/man' + section + '/' + name + '.' + section + '.html';
+        var url = 'https://cs-education.github.io/sysassets/man_pages/html/man' + section + '/' + name + '.' + section + '.html';
         return {
             tabName: name + ' (' + section + ')',
             tabHtml: '<iframe style="width: 100%; height: 100%" src="' + url + '"></iframe>'

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -27,7 +27,7 @@ window.Router = (function () {
                     };
                 } else if (viewModel.chapters().length === 0) {
                     // Load chapters
-                    jqxhr = $.getJSON('http://angrave.github.io/sysassets/sys.min.json', function (data) {
+                    jqxhr = $.getJSON('http://cs-education.github.io/sysassets/sys.min.json', function (data) {
                         viewModel.chapters(data.chapters);
                     }).fail(function () {
                         // Getting file failed, don't try again
@@ -93,7 +93,7 @@ window.Router = (function () {
             };
 
             if (playActivity.docFile) {
-                $.get('http://angrave.github.io/sysassets/' + playActivity.docFile).done(cb).fail(function () {
+                $.get('http://cs-education.github.io/sysassets/' + playActivity.docFile).done(cb).fail(function () {
                     cb(playActivity.doc || '');
                 });
             } else {
@@ -106,7 +106,7 @@ window.Router = (function () {
                 viewModel.shownPage('video');
                 Tracker.getInstance().trackPageView();
 
-                var currentVideoFilePrefix = 'https://angrave.github.io/sysassets/' + videoActivity.file;
+                var currentVideoFilePrefix = 'https://cs-education.github.io/sysassets/' + videoActivity.file;
                 viewModel.currentVideoFilePrefix(currentVideoFilePrefix);
                 viewModel.currentVideoTopics(videoActivity.topics || '');
                 viewModel.currentVideoDoc(marked(doc));
@@ -133,7 +133,7 @@ window.Router = (function () {
             };
 
             if (videoActivity.docFile) {
-                $.get('http://angrave.github.io/sysassets/' + videoActivity.docFile).done(cb).fail(function () {
+                $.get('http://cs-education.github.io/sysassets/' + videoActivity.docFile).done(cb).fail(function () {
                     cb(videoActivity.doc || '');
                 });
             } else {

--- a/app/scripts/router.js
+++ b/app/scripts/router.js
@@ -27,7 +27,7 @@ window.Router = (function () {
                     };
                 } else if (viewModel.chapters().length === 0) {
                     // Load chapters
-                    jqxhr = $.getJSON('sysassets/sys.min.json', function (data) {
+                    jqxhr = $.getJSON('http://angrave.github.io/sysassets/sys.min.json', function (data) {
                         viewModel.chapters(data.chapters);
                     }).fail(function () {
                         // Getting file failed, don't try again
@@ -93,7 +93,7 @@ window.Router = (function () {
             };
 
             if (playActivity.docFile) {
-                $.get('sysassets/' + playActivity.docFile).done(cb).fail(function () {
+                $.get('http://angrave.github.io/sysassets/' + playActivity.docFile).done(cb).fail(function () {
                     cb(playActivity.doc || '');
                 });
             } else {
@@ -133,7 +133,7 @@ window.Router = (function () {
             };
 
             if (videoActivity.docFile) {
-                $.get('sysassets/' + videoActivity.docFile).done(cb).fail(function () {
+                $.get('http://angrave.github.io/sysassets/' + videoActivity.docFile).done(cb).fail(function () {
                     cb(videoActivity.doc || '');
                 });
             } else {

--- a/app/scripts/xdomain.js
+++ b/app/scripts/xdomain.js
@@ -1,7 +1,8 @@
-(function(){
+/* global xdomain */
+(function () {
     'use strict';
 
     xdomain.slaves({
-        "http://angrave.github.io": "/sysassets/proxy.html"
+        'http://angrave.github.io': '/sysassets/proxy.html'
     });
 })();

--- a/app/scripts/xdomain.js
+++ b/app/scripts/xdomain.js
@@ -1,0 +1,7 @@
+(function(){
+    'use strict';
+
+    xdomain.slaves({
+        "http://angrave.github.io": "/sysassets/proxy.html"
+    });
+})();

--- a/app/scripts/xdomain.js
+++ b/app/scripts/xdomain.js
@@ -3,6 +3,6 @@
     'use strict';
 
     xdomain.slaves({
-        'http://angrave.github.io': '/sysassets/proxy.html'
+        'http://cs-education.github.io': '/sysassets/proxy.html'
     });
 })();

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "sammy": "~0.7.6",
     "marked": "~0.3.2",
     "videojs": "~4.8.1",
-    "typeahead.js": "~0.10.5"
+    "typeahead.js": "~0.10.5",
+    "xdomain": "~0.6.17"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Resolves #70 

The usual way to define a slave is to use an HTML attribute:
`<script src="<path>/xdomain.min.js" slave="<url>/proxy.html"></script>`. However, this ended up not working. I believe the issue was caused by one of the minification steps in the build process, but I don't know for sure.

I fixed the issue by manually defining the slave using javascript (see xdomain.js).

Some questions I have:
  - Is naming the file `xdomain.js` confusing? (don't want to confuse it with the library itself)
  - Should the xdomain code snippet even be in its own file? It's important that this code snippet occurs before any network calls, however, or else any calls to sysassets made before the xdomain slave is set could result in a CORS error.

Also, @neelabhg I would appreciate you double-checking my changes to the Gruntfile to ensure I haven't broken our build process. However, my deploy to sys-staging appears to be functioning just fine.