### PR TITLE
Bugfix#88: Build process to include notific8 fonts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -371,6 +371,12 @@ module.exports = function (grunt) {
                     cwd: './sys-gh-pages-config/',
                     src: ['README.md'],
                     dest: '<%= config.dist %>'
+                }, {
+                    expand: true,
+                    dot: true,
+                    cwd: 'bower_components/jquery-notific8/dist/fonts/',
+                    src: ['*.*'],
+                    dest: '<%= config.dist %>/styles/font/'
                 }]
             },
             styles: {

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -56,3 +56,16 @@ $icon-font-path: "../bower_components/bootstrap-sass-official/vendor/assets/font
 .label-default-light {
     @include label-variant(lighten($label-default-bg, 25%));
 }
+
+// Overriding jquery.notific8 font dir
+@font-face {
+    font-family: "notific8";
+    src:url("font/notific8.eot") !important;
+    src:url("font/notific8.eot?#iefix") format("embedded-opentype"),
+    url("font/notific8.woff") format("woff"),
+    url("font/notific8.ttf") format("truetype"),
+    url("font/notific8.svg#notific8") format("svg") !important;
+    font-weight: normal;
+    font-style: normal;
+
+}


### PR DESCRIPTION
Changes:

* Added a block in the copy command in the gruntfile to copy the fonts for notific8 during build process.
* Overrode the font-face 'notific8' to look for font files in the 'font' directory instead of 'fonts'.

Closes #88