### PR TITLE
Fixed jor1k dependency in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "modernizr": "~2.6.2",
     "jquery": "~1.11.0",
     "ace-builds": "~1.1.5",
-    "jor1k": "https://github.com/cs-education/jor1k.git#master",
+    "jor1k": "https://github.com/cs-education/jor1k.git#sysbuild-stable",
     "jquery.layout": "*",
     "knockout": "~3.2.0",
     "Blob": "*",


### PR DESCRIPTION
This change reflects our plans for sysbuild to pull from the "stable" branch of our organization's jor1k fork.