### PR TITLE
Bug Fix#107 - Typeahead search box

### DIFF
--- a/app/styles/_typeahead.scss
+++ b/app/styles/_typeahead.scss
@@ -55,7 +55,7 @@
 .tt-hint {
     width: 574px;
     height: 30px;
-    padding: 8px 12px;
+    padding: 0px 12px;
     font-size: 24px;
     line-height: 30px;
     border: 1px solid #024e6a;


### PR DESCRIPTION
Change:

* Removed the top and bottom paddings in typeahead class in _typeahead.scss .

There is no change in chrome but for firefox the cropping goes away.

Closes #107