### PR TITLE
Disable live reloading in grunt serve (when serving development files)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,7 +104,7 @@ module.exports = function (grunt) {
                 // Change this to '0.0.0.0' to access the server from outside
                 hostname: 'localhost'
             },
-            livereload: {
+            develop: {
                 options: {
                     middleware: function (connect) {
                         return [
@@ -112,7 +112,8 @@ module.exports = function (grunt) {
                             connect().use('/bower_components', connect.static('./bower_components')),
                             connect.static(config.app)
                         ];
-                    }
+                    },
+                    livereload: false
                 }
             },
             test: {
@@ -453,7 +454,7 @@ module.exports = function (grunt) {
             'clean:server',
             'concurrent:server',
             'autoprefixer',
-            'connect:livereload',
+            'connect:develop',
             'watch'
         ]);
     });

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ because of the [location npm installs global packages](https://www.npmjs.org/doc
 `npm install`
 
 ## Useful commands ##
-* Run a development server. Automatically launches default browser. Also supports live reloading, which means
-  changes automatically show up without the need to refresh the page. Files are also watched for changes - 
-  JSHint is automatically run on the changed JS files, changed SASS files are automatically compiled, etc.  
+* Run a development server. Automatically launches default browser. Files are also watched for changes - 
+  JSHint is automatically run on the changed JS files, changed SASS files are automatically compiled, etc.
+  You do need to refresh the web page after making any changes (live reloading has been disabled
+  due to [this issue](https://github.com/cs-education/sysbuild/issues/115)).  
   `grunt serve`
 
 * If you add a new bower component, you might want to automatically inject *supported* Bower components into the HTML file.  


### PR DESCRIPTION
The live reloading plugin corrupts some binary files (specifically, vmlinux.bin.bz2) when serving to Firefox (see #115). Disabling live reloading fixes the issue, but loses the benefit of live reloading (which I personally don't care about much).

This PR effectively closes #115.