### PR TITLE
Prevent users from accidentally navigate the page backward

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -165,6 +165,15 @@ $(document).ready(function () {
     $(window).resize(function () {
         editor.resize(500);
         resizeTabs();
+    }).on('keydown', function (e) {
+        // prevent accidental backward navigation
+        var keyCode = {
+            backspace: 8
+        };
+
+        if (e.keyCode === keyCode.backspace) {
+            e.preventDefault();
+        }
     });
 
     $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {


### PR DESCRIPTION
When I was taking CS 241, I had this problem.
Somehow the focus was out of the ACE editor and pressing backspace key made my browser to go back which was blank chrome tab because I accessed playground through my bookmark .
In this case, the whole lines of code would be lost.

I added `e.preventDefault()` on pressing backspace key on `window` keydown event.

<!---
@huboard:{"order":121.0,"milestone_order":126,"custom_state":""}
-->
