### PR TITLE
Fix jor1k setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 cache:
   directories:
   - node_modules
-  - bower_components
-before_install: npm install -g bower grunt-cli
+  - src/bower_modules
+before_install: npm install -g bower
 notifications:
   email: false
   webhooks:

--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,7 @@
     "jquery-ui": "~1.11.4",
     "jquery-fullscreen": "~1.1.4",
     "cjs": "*",
-    "ace": "~1.2.2",
-    "requirejs-web-workers": "~1.0.1"
+    "ace": "~1.2.2"
   },
   "devDependencies": {},
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "jquery-ui": "~1.11.4",
     "jquery-fullscreen": "~1.1.4",
     "cjs": "*",
-    "ace": "~1.2.2"
+    "ace": "~1.2.2",
+    "requirejs-web-workers": "~1.0.1"
   },
   "devDependencies": {},
   "resolutions": {

--- a/gulp-tasks/babel-transpiler.js
+++ b/gulp-tasks/babel-transpiler.js
@@ -9,7 +9,7 @@ class BabelTranspiler {
     constructor(root) {
         this.config = {
             root: root || 'src',
-            skip: ['bower_modules/**', 'app/require.config.js', 'test/require.config.js'],
+            skip: ['bower_modules/**', 'app/require.config.js', 'test/require.config.js', 'app/jor1k-worker-wrapper.js'],
             babelConfig: {
                 modules: 'amd',
                 sourceMaps: 'inline'

--- a/gulp-tasks/build-js.js
+++ b/gulp-tasks/build-js.js
@@ -14,7 +14,8 @@ const requireJsOptimizerBaseConfig = {
     mainConfigFile: 'src/app/require.config.js',
     baseUrl: './src',
     paths: {
-        requireLib: 'bower_modules/requirejs/require'
+        requireLib: 'bower_modules/requirejs/require',
+        'app/config': 'app/config/config.dist'
     }
 };
 
@@ -62,7 +63,7 @@ const requireJsOptimizerFilesConfig = [
     },
     {
         // Jor1k worker
-        out: 'app/jor1k-worker-wrapper.js',
+        out: 'jor1k-worker.js',
         name: 'cjs!jor1k/worker/worker',
         include: [
             'app/require.config',

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -4,7 +4,6 @@ import es from 'event-stream';
 import chalk from 'chalk';
 import gulp from 'gulp';
 import clean from 'gulp-clean';
-import uglify from 'gulp-uglify';
 import size from 'gulp-size';
 
 import './gulp-tasks/build-js';
@@ -26,25 +25,16 @@ gulp.task('clean', () => {
         .pipe(clean());
 });
 
-// Copies the Jor1k Web Worker script file, the VM disk image, and the filesystem files
-gulp.task('jor1k', () => {
-    const workerJs = gulp.src('./src/bower_modules/jor1k/bin/jor1k-worker-min.js')
-        .pipe(uglify({ preserveComments: 'some' }));
-    const fsFiles = gulp.src('./src/bower_modules/jor1k/bin/{vmlinux.bin.bz2,basefs-compile.json,sysroot/**}');
-    return es.concat(workerJs, fsFiles)
-        .pipe(gulp.dest('./dist/bower_modules/jor1k/bin/'));
-});
-
-gulp.task('build', ['lint', 'html', 'js', 'css:dist', 'fonts', 'images', 'extras', 'jor1k'], () => {
+gulp.task('build', ['lint', 'html', 'js', 'css:dist', 'fonts', 'images', 'extras'], () => {
     console.log('\nPlaced optimized files in ' + chalk.magenta('dist/\n'));
     const buildStampFile = 'dist/build-stamp.txt';
     const recentCommitsFile = 'dist/publish-recentcommits.txt';
 
     const s = size({title: 'dist'});
     const buildStamp = gulp.src('dist/**/*').pipe(s).on('end', () => {
-            fs.writeFileSync(buildStampFile, `Build date: ${(new Date()).toUTCString()}\nBuilt size: ${s.prettySize}\n`);
-            console.log('Build stamp written to ' + chalk.magenta(buildStampFile));
-        });
+        fs.writeFileSync(buildStampFile, `Build date: ${(new Date()).toUTCString()}\nBuilt size: ${s.prettySize}\n`);
+        console.log('Build stamp written to ' + chalk.magenta(buildStampFile));
+    });
 
     const recentCommitLog = cp.exec('git log -n 5 --oneline', (err, stdout) => {
         if (err) throw err;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,7 +33,6 @@ module.exports = function(config) {
         'karma-jasmine',
         'karma-requirejs',
         'karma-babel-preprocessor',
-        'karma-requireglobal-preprocessor',
         'karma-chrome-launcher',
         'karma-phantomjs-launcher'
     ],
@@ -41,7 +40,6 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-        '**/require.config.js': ['requireglobal'],
         'src/app/{!(require.config), **/*}.js': ['babel'],
         'src/components/**/*.js': ['babel'],
         'test/app/**/*.js': ['babel'],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "babel-core": "^5.8.34",
     "chalk": "~0.4.0",
     "deeply": "~0.1.0",
-    "event-stream": "~3.1.0",
+    "event-stream": "^3.3.2",
     "gulp": "^3.6.2",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-babel": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "karma-chrome-launcher": "^0.2.1",
     "karma-jasmine": "^0.3.6",
     "karma-phantomjs-launcher": "^0.2.1",
-    "karma-requireglobal-preprocessor": "^0.0.0",
     "karma-requirejs": "^0.2.2",
     "object-assign": "^4.0.1",
     "phantomjs": "^1.9.19",

--- a/src/app/config/config.dev.js
+++ b/src/app/config/config.dev.js
@@ -1,0 +1,2 @@
+export const jor1kBaseFsUrl = 'https://cs-education.github.io/sysassets/jor1kfs/sysroot/or1k/';
+export const jor1kWorkerUrl = 'app/jor1k-worker-wrapper.js';

--- a/src/app/config/config.dist.js
+++ b/src/app/config/config.dist.js
@@ -1,0 +1,2 @@
+export const jor1kBaseFsUrl = 'https://cs-education.github.io/sysassets/jor1kfs/sysroot/or1k/';
+export const jor1kWorkerUrl = 'jor1k-worker.js';

--- a/src/app/jor1k-worker-wrapper.js
+++ b/src/app/jor1k-worker-wrapper.js
@@ -1,8 +1,8 @@
 /* Required for development only */
-
-importScripts('require.config.js');
-require.baseUrl = '../../';
 importScripts('../bower_modules/requirejs/require.js');
+importScripts('require.config.js');
+require.config({baseUrl: '../'});
+
 
 // see https://github.com/guybedford/amd-loader/issues/4
 var window = self; // returns a reference to the WorkerGlobalScope

--- a/src/app/jor1k-worker-wrapper.js
+++ b/src/app/jor1k-worker-wrapper.js
@@ -1,8 +1,14 @@
-/* Required for development only */
+/**
+ * This file is used only during development, so that RequireJS and
+ * its configuration could be loaded inside the worker using
+ * importScripts. For production, the Jor1k worker along with
+ * RequireJS is included directly during build.
+ */
+
+/*global importScripts, require*/
 importScripts('../bower_modules/requirejs/require.js');
 importScripts('require.config.js');
 require.config({baseUrl: '../'});
-
 
 // see https://github.com/guybedford/amd-loader/issues/4
 var window = self; // returns a reference to the WorkerGlobalScope

--- a/src/app/jor1k-worker-wrapper.js
+++ b/src/app/jor1k-worker-wrapper.js
@@ -1,0 +1,10 @@
+/* Required for development only */
+
+importScripts('require.config.js');
+require.baseUrl = '../../';
+importScripts('../bower_modules/requirejs/require.js');
+
+// see https://github.com/guybedford/amd-loader/issues/4
+var window = self; // returns a reference to the WorkerGlobalScope
+
+require(['cjs!jor1k/worker/worker']);

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -24,9 +24,7 @@ var require = {
         "FileSaver":            "bower_modules/FileSaver/FileSaver.min", // exports window global "saveAs"
         "Blob":                 "bower_modules/Blob/Blob", // exports window global "Blob"
         "cjs":                  "bower_modules/cjs/cjs",
-        "amd-loader":           "bower_modules/amd-loader/amd-loader",
-        "worker":               "bower_modules/requirejs-web-workers/src/worker",
-        "jor1k-worker":         "app/jor1k-worker-wrapper.js"
+        "amd-loader":           "bower_modules/amd-loader/amd-loader"
     },
     shim: {
         "bootstrap": { deps: ["jquery"] },

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -1,6 +1,5 @@
 /*eslint quotes: [2, "double"]*/
-// require.js looks for the following global when initializing
-var require = {
+require.config({
     baseUrl: ".",
     paths: {
         "bootstrap":            "bower_modules/bootstrap-sass/assets/javascripts/bootstrap.min",
@@ -62,4 +61,4 @@ var require = {
             "jor1k/worker/riscv/htif": "jor1k/worker/riscv/htif"
         }
     }
-};
+});

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -24,7 +24,9 @@ var require = {
         "FileSaver":            "bower_modules/FileSaver/FileSaver.min", // exports window global "saveAs"
         "Blob":                 "bower_modules/Blob/Blob", // exports window global "Blob"
         "cjs":                  "bower_modules/cjs/cjs",
-        "amd-loader":           "bower_modules/amd-loader/amd-loader"
+        "amd-loader":           "bower_modules/amd-loader/amd-loader",
+        "worker":               "bower_modules/requirejs-web-workers/src/worker",
+        "jor1k-worker":         "app/jor1k-worker-wrapper.js"
     },
     shim: {
         "bootstrap": { deps: ["jquery"] },
@@ -38,5 +40,28 @@ var require = {
             name: "jor1k",
             location: "bower_modules/jor1k/js"
         }
-    ]
+    ],
+    map: {
+        // The 'system.js' file in the jor1k worker source 'require()'s the 'or1k' and 'riscv'
+        // directories to load 'or1k/index.js' and 'riscv/index.js', respectively. Such a require
+        // call is supported in CommonJS environments, but not in AMD/RequireJS. The following
+        // mapping rules convert the directory requires into the correct module IDs to be loaded.
+        "jor1k/worker/system": {
+            // the following rule ensures that require('./or1k') will load './or1k/index.js'
+            "jor1k/worker/or1k": "jor1k/worker/or1k/index",
+
+            // this following rule overrides the above rule when the 'jor1k/worker/or1k/index'
+            // module ID is normalized, to prevent 'jor1k/worker/or1k/index' being incorrectly
+            // mapped to 'jor1k/worker/or1k/index/index'
+            "jor1k/worker/or1k/index": "jor1k/worker/or1k/index",
+
+             // similar to above
+            "jor1k/worker/riscv": "jor1k/worker/riscv/index",
+            "jor1k/worker/riscv/index": "jor1k/worker/riscv/index",
+
+            // the following rule prevents 'jor1k/worker/riscv/htif' from being incorrectly
+            // mapped to 'jor1k/worker/riscv/index/htif'
+            "jor1k/worker/riscv/htif": "jor1k/worker/riscv/htif"
+        }
+    }
 };

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -3,6 +3,12 @@
 require.config({
     baseUrl: ".",
     paths: {
+        // RequireJS plugins
+        "text":                 "bower_modules/requirejs-text/text",
+        "cjs":                  "bower_modules/cjs/cjs",
+        "amd-loader":           "bower_modules/amd-loader/amd-loader",
+
+        // Library/external dependencies
         "bootstrap":            "bower_modules/bootstrap-sass/assets/javascripts/bootstrap.min",
         "modernizr":            "bower_modules/modernizr/modernizr",
         "crossroads":           "bower_modules/crossroads/dist/crossroads.min",
@@ -11,7 +17,6 @@ require.config({
         "knockout":             "bower_modules/knockout/dist/knockout",
         "knockout-projections": "bower_modules/knockout-projections/dist/knockout-projections",
         "signals":              "bower_modules/js-signals/dist/signals.min",
-        "text":                 "bower_modules/requirejs-text/text",
         "marked":               "bower_modules/marked/marked.min",
         "videojs":              "bower_modules/videojs/dist/video.min",
         "jquery-ui":            "bower_modules/jquery-ui/jquery-ui.min",
@@ -23,8 +28,8 @@ require.config({
         "bloodhound":           "bower_modules/typeahead.js/dist/bloodhound.min", // exports window global "Bloodhound"
         "FileSaver":            "bower_modules/FileSaver/FileSaver.min", // exports window global "saveAs"
         "Blob":                 "bower_modules/Blob/Blob", // exports window global "Blob"
-        "cjs":                  "bower_modules/cjs/cjs",
-        "amd-loader":           "bower_modules/amd-loader/amd-loader",
+
+        // Application-specific modules
         "app/config":           "app/config/config.dev" // overridden to 'config.dist' in build config
     },
     shim: {

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -1,3 +1,4 @@
+/*global require*/
 /*eslint quotes: [2, "double"]*/
 require.config({
     baseUrl: ".",

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -24,7 +24,8 @@ require.config({
         "FileSaver":            "bower_modules/FileSaver/FileSaver.min", // exports window global "saveAs"
         "Blob":                 "bower_modules/Blob/Blob", // exports window global "Blob"
         "cjs":                  "bower_modules/cjs/cjs",
-        "amd-loader":           "bower_modules/amd-loader/amd-loader"
+        "amd-loader":           "bower_modules/amd-loader/amd-loader",
+        "app/config":           "app/config/config.dev" // overridden to 'config.dist' in build config
     },
     shim: {
         "bootstrap": { deps: ["jquery"] },

--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -2,7 +2,6 @@ import ExpectTTY from 'app/expect-tty';
 import GccOutputParser from 'app/gcc-output-parser';
 import * as Jor1k from 'cjs!jor1k/master/master';
 import LinuxTerm from 'cjs!jor1k/plugins/terminal-linux';
-import jor1kWorker from 'worker!jor1k-worker';
 
 // Encapsulates the virtual machine interface
 class SysRuntime {
@@ -100,7 +99,7 @@ class SysRuntime {
             statsid: 'vm-stats',  // element id for displaying VM statistics
             memorysize: 32, // in MB, must be a power of two
             path: 'bower_modules/jor1k/demos/',
-            worker: jor1kWorker
+            worker: new Worker('app/jor1k-worker-wrapper.js')
         };
 
         this.jor1kgui = new Jor1k(jor1kparameters);

--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -1,7 +1,7 @@
 import ExpectTTY from 'app/expect-tty';
 import GccOutputParser from 'app/gcc-output-parser';
 import * as Jor1k from 'cjs!jor1k/master/master';
-import MackeTerm from 'cjs!jor1k/plugins/terminal-macke';
+import LinuxTerm from 'cjs!jor1k/plugins/terminal-linux';
 
 // Encapsulates the virtual machine interface
 class SysRuntime {
@@ -68,8 +68,8 @@ class SysRuntime {
             }
         };
 
-        var termTTY0 = new MackeTerm('tty0');
-        var termTTY1 = new MackeTerm('tty1');
+        var termTTY0 = new LinuxTerm('tty0');
+        var termTTY1 = new LinuxTerm('tty1');
 
         var jor1kparameters = {
             system: {
@@ -98,7 +98,8 @@ class SysRuntime {
             terms: [termTTY0, termTTY1],   // canvas ids for the terminals
             statsid: 'vm-stats',  // element id for displaying VM statistics
             memorysize: 32, // in MB, must be a power of two
-            path: 'bower_modules/jor1k/bin/'
+            path: 'bower_modules/jor1k/demos/',
+            worker: new Worker('bower_modules/jor1k/demos/jor1k-worker-min.js')
         };
 
         this.jor1kgui = new Jor1k(jor1kparameters);

--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -2,6 +2,7 @@ import ExpectTTY from 'app/expect-tty';
 import GccOutputParser from 'app/gcc-output-parser';
 import * as Jor1k from 'cjs!jor1k/master/master';
 import LinuxTerm from 'cjs!jor1k/plugins/terminal-linux';
+import { jor1kBaseFsUrl, jor1kWorkerUrl } from 'app/config';
 
 // Encapsulates the virtual machine interface
 class SysRuntime {
@@ -97,8 +98,8 @@ class SysRuntime {
             terms: [termTTY0, termTTY1],   // canvas ids for the terminals
             statsid: 'vm-stats',  // element id for displaying VM statistics
             memorysize: 32, // in MB, must be a power of two
-            path: 'https://cs-education.github.io/sysassets/jor1kfs/sysroot/or1k/', // kernelURL and fsURLs are relative to this path
-            worker: new Worker('app/jor1k-worker-wrapper.js')
+            path: jor1kBaseFsUrl, // kernelURL and fsURLs are relative to this path
+            worker: new Worker(jor1kWorkerUrl)
         };
 
         this.jor1kgui = new Jor1k(jor1kparameters);

--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -78,11 +78,10 @@ class SysRuntime {
                 cpu: 'asm', // short name for the cpu to use
                 ncores: 1
             },
-
             fs: {
                 basefsURL: 'basefs-compile.json', // json file with the basic filesystem configuration.
                 // json file with extended filesystem informations. Loaded after the basic filesystem has been loaded.
-                extendedfsURL: 'https://cs-education.github.io/sysassets/jor1kfs/sysroot/fs.json',
+                extendedfsURL: '../fs.json',
                 earlyload: [
                     'usr/bin/gcc',
                     'usr/libexec/gcc/or1k-linux-musl/4.9.0/cc1',
@@ -98,7 +97,7 @@ class SysRuntime {
             terms: [termTTY0, termTTY1],   // canvas ids for the terminals
             statsid: 'vm-stats',  // element id for displaying VM statistics
             memorysize: 32, // in MB, must be a power of two
-            path: 'bower_modules/jor1k/demos/',
+            path: 'https://cs-education.github.io/sysassets/jor1kfs/sysroot/or1k/', // kernelURL and fsURLs are relative to this path
             worker: new Worker('app/jor1k-worker-wrapper.js')
         };
 

--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -2,6 +2,7 @@ import ExpectTTY from 'app/expect-tty';
 import GccOutputParser from 'app/gcc-output-parser';
 import * as Jor1k from 'cjs!jor1k/master/master';
 import LinuxTerm from 'cjs!jor1k/plugins/terminal-linux';
+import jor1kWorker from 'worker!jor1k-worker';
 
 // Encapsulates the virtual machine interface
 class SysRuntime {
@@ -99,10 +100,11 @@ class SysRuntime {
             statsid: 'vm-stats',  // element id for displaying VM statistics
             memorysize: 32, // in MB, must be a power of two
             path: 'bower_modules/jor1k/demos/',
-            worker: new Worker('bower_modules/jor1k/demos/jor1k-worker-min.js')
+            worker: jor1kWorker
         };
 
         this.jor1kgui = new Jor1k(jor1kparameters);
+
         termTTY0.SetCharReceiveListener(this.putCharTTY0Listener);
         termTTY1.SetCharReceiveListener(this.putCharTTY1Listener);
 

--- a/src/index.html
+++ b/src/index.html
@@ -17,8 +17,12 @@
       <link href="styles.css" rel="stylesheet">
     <!-- endbuild -->
     <!-- build:js -->
-      <script src="app/require.config.js"></script>
-      <script data-main="app/startup" src="bower_modules/requirejs/require.js"></script>
+      <script src="bower_modules/requirejs/require.js"></script>
+      <script>
+      require(['app/require.config'], function () {
+        require(['app/startup']);
+      });
+      </script>
     <!-- endbuild -->
   </head>
   <body>

--- a/test/SpecRunner.karma.js
+++ b/test/SpecRunner.karma.js
@@ -7,7 +7,7 @@ for (var file in window.__karma__.files) {
   }
 }
 
-requirejs.config({
+require.config({
     baseUrl: '/base/src',
     deps: tests,
     callback: window.__karma__.start

--- a/test/index.html
+++ b/test/index.html
@@ -6,9 +6,12 @@
   <link rel="stylesheet" type="text/css" href="bower_modules/jasmine/lib/jasmine-core/jasmine.css">
 
   <!-- Combine require configs from both src and test, then load the runner -->
-  <script src="../src/app/require.config.js"></script>
-  <script src="require.config.js"></script>
-  <script src="bower_modules/requirejs/require.js" data-main="../test/SpecRunner.browser"></script>
+  <script src="bower_modules/requirejs/require.js"></script>
+  <script>
+    require(['../src/app/require.config', '../test/require.config'], function () {
+      require(['../test/SpecRunner.browser']);
+    });
+  </script>
 </head>
 
 <body>

--- a/test/require.config.js
+++ b/test/require.config.js
@@ -1,15 +1,18 @@
-(function () {
+require.config({
   // Resolve all AMD modules relative to the 'src' directory, to produce the
   // same behavior that occurs at runtime
-  require.baseUrl = '../src/';
+  baseUrl: '../src/',
 
   // It's not obvious, but this is a way of making Jasmine load and run in an AMD environment
   // Credit: http://stackoverflow.com/a/20851265
-  var jasminePath = '../test/bower_modules/jasmine/lib/jasmine-core/';
-  require.paths['jasmine'] = jasminePath + 'jasmine';
-  require.paths['jasmine-html'] = jasminePath + 'jasmine-html';
-  require.paths['jasmine-boot'] = jasminePath + 'boot';
-  require.shim['jasmine'] = { exports: 'window.jasmineRequire' };
-  require.shim['jasmine-html'] = { deps: ['jasmine'], exports: 'window.jasmineRequire' };
-  require.shim['jasmine-boot'] = { deps: ['jasmine', 'jasmine-html'], exports: 'window.jasmineRequire' };
-})();
+  paths: {
+    'jasmine': '../test/bower_modules/jasmine/lib/jasmine-core/jasmine',
+    'jasmine-html': '../test/bower_modules/jasmine/lib/jasmine-core/jasmine-html',
+    'jasmine-boot': '../test/bower_modules/jasmine/lib/jasmine-core/boot'
+  },
+  shim: {
+    'jasmine': { exports: 'window.jasmineRequire' },
+    'jasmine-html':  { deps: ['jasmine'], exports: 'window.jasmineRequire' },
+    'jasmine-boot': { deps: ['jasmine', 'jasmine-html'], exports: 'window.jasmineRequire' }
+  }
+});


### PR DESCRIPTION
Pull request #128 did not take updates to the jor1k folder structure into account, breaking the development and build setups of people with the latest bower dependencies (including new clones of this repo). This PR fixes and improves the way jor1k is imported and included in our application, including a cleaner way of building and including the jor1k worker script.

The individual commit messages provide detailed explanations of the changes introduced in this PR.
