### PR TITLE
Updated Error Detection

### DIFF
--- a/src/app/gcc-output-parser.js
+++ b/src/app/gcc-output-parser.js
@@ -28,8 +28,8 @@ class GccOutputParser {
 
                 if (lineColTypeMatch) {//num:num: string
                     file = match[1];
-                    row = lineColTypeMatch[1];
-                    col = lineColTypeMatch[2];
+                    row = parseInt(lineColTypeMatch[1]);
+                    col = parseInt(lineColTypeMatch[2]);
                     typeTextSplitMatch = gccOutputTypeTextSplitRe.exec(lineColTypeMatch[3]);
                     if (typeTextSplitMatch) {
                         buildErrorType = typeTextSplitMatch[1];

--- a/src/app/gcc-output-parser.js
+++ b/src/app/gcc-output-parser.js
@@ -1,11 +1,14 @@
 const gccOutputParseRe = /(.+?):\s*(.+)\s*:\s*(.+)\s*/;
 const gccRowColTypeParseRe = /(\d+):(\d+):\s*(.+)/;
 const gccOutputTypeTextSplitRe = /\s*(.+)\s*:\s*(.+)\s*/;
+const makeOutputTypeTextSplitRe = /(.+?):(\d+):\s*(.+)/;
+const makeErrorSplitRe = /make:\s\*\*\*\s*(.+)/;
+
 const errorTypeMap = {
-    'program.c': 'compile',
     'gcc': 'gcc',
     'cc1': 'gcc',
-    'collect2': 'linker'
+    'collect2': 'linker',
+    'make': 'make'
 };
 
 class GccOutputParser {
@@ -13,47 +16,77 @@ class GccOutputParser {
         // empty
     }
 
-    parse(gccOutputStr) {
-        var match, lineColTypeMatch, typeTextSplitMatch, row, col, gccErrorType, text, errors = [];
+    parse(buildOutputStr) {
+        var match, makeErr, lineColTypeMatch, typeTextSplitMatch, makefileColNum, row, col, buildErrorType, text, file, errors = [];
 
-        gccOutputStr.split('\n').forEach((errorLine) => {
+        buildOutputStr.split('\n').forEach(function (errorLine) {
             match = gccOutputParseRe.exec(errorLine);
+            makeErr = makeErrorSplitRe.exec(errorLine);
 
-            if (match) {
+            if (match) { //two colons
                 lineColTypeMatch = gccRowColTypeParseRe.exec(match[2]);
 
-                if (lineColTypeMatch) {
-                    row = parseInt(lineColTypeMatch[1], 10);
-                    col = parseInt(lineColTypeMatch[2], 10);
+                if (lineColTypeMatch) {//num:num: string
+                    file = match[1];
+                    row = lineColTypeMatch[1];
+                    col = lineColTypeMatch[2];
                     typeTextSplitMatch = gccOutputTypeTextSplitRe.exec(lineColTypeMatch[3]);
                     if (typeTextSplitMatch) {
-                        gccErrorType = typeTextSplitMatch[1];
+                        buildErrorType = typeTextSplitMatch[1];
                         text = typeTextSplitMatch[2] + ': ' + match[3];
                     } else {
-                        gccErrorType = lineColTypeMatch[3];
+                        buildErrorType = lineColTypeMatch[3];
                         text = match[3];
                     }
                 } else {
                     // some gcc output without line info
-                    row = col = 0;
-                    typeTextSplitMatch = gccOutputTypeTextSplitRe.exec(match[2]);
-                    if (typeTextSplitMatch) {
-                        gccErrorType = typeTextSplitMatch[1];
-                        text = typeTextSplitMatch[2] + ': ' + match[3];
-                    } else {
-                        gccErrorType = match[2];
-                        text = match[3];
+                    makefileColNum = makeOutputTypeTextSplitRe.exec(match[0]);
+
+                    if(makefileColNum){
+                        file = makefileColNum[1];
+                        row = makefileColNum[2];
+                        text = makefileColNum[3];
+                        buildErrorType = 'error';
+                    }
+                    else{
+                        row = col = 0;
+                        typeTextSplitMatch = gccOutputTypeTextSplitRe.exec(match[2]);
+                        if (typeTextSplitMatch) {
+                            buildErrorType = typeTextSplitMatch[1];
+                            text = typeTextSplitMatch[2] + ': ' + match[3];
+                        } else {
+                            buildErrorType = match[2];
+                            text = match[3];
+                        }
                     }
                 }
+
+
+                var mappedType = errorTypeMap[match[1]];
+                if(!mappedType) mappedType = 'compile';
 
                 errors.push({
                     row: row,
                     column: col,
-                    type: errorTypeMap[match[1]],
-                    gccErrorType: gccErrorType,
-                    text: text
+                    type: mappedType,
+                    buildErrorType: buildErrorType,
+                    text: text,
+                    file: file
                 });
             }
+            else if(makeErr)
+            {
+                errors.push({
+                    row: 0,
+                    column: 0,
+                    type: 'make',
+                    buildErrorType: 'error',
+                    text: '*** '+makeErr[1],
+                    file: undefined
+                });
+            }
+
+
         });
 
         return errors;

--- a/src/app/live-edit.js
+++ b/src/app/live-edit.js
@@ -47,10 +47,10 @@ class LiveEdit {
 
         this.runtime.sendKeys('tty0', 'clear\n');
 
-        var aceAnnotations = [], gccOptsErrors = [];
+        var aceAnnotations = [], buildCmdErrors = [];
         result.annotations.forEach((annotation) => {
-            if (annotation.isGccOptsError) {
-                gccOptsErrors.push(annotation);
+            if (annotation.isBuildCmdError) {
+                buildCmdErrors.push(annotation);
             } else {
                 aceAnnotations.push(annotation);
             }
@@ -60,7 +60,7 @@ class LiveEdit {
         SysGlobalObservables.lastGccOutput(result.gccOutput);
         SysGlobalObservables.gccErrorCount(result.stats.error);
         SysGlobalObservables.gccWarningCount(result.stats.warning);
-        SysGlobalObservables.gccOptsError(gccOptsErrors.map((error) => error.text).join('\n'));
+        SysGlobalObservables.gccOptsError(buildCmdErrors.map((error) => error.text).join('\n'));
 
         if (result.exitCode === 0) {
             SysGlobalObservables.compileStatus(result.stats.warning > 0 ? 'Warnings' : 'Success');

--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -181,15 +181,21 @@ class SysRuntime {
         return this.compileTicket;
     }
 
-    getErrorAnnotations(gccOutputStr) {
-        var errors = (new GccOutputParser()).parse(gccOutputStr);
+    getErrorAnnotations(buildOutputStr) {
+        var workingDir = buildOutputStr.substr(0, buildOutputStr.indexOf('\n'));
+        if(workingDir.indexOf('/home/user') == 0)
+            workingDir = workingDir.substr(10, workingDir.length);
+        else
+            workingDir = '';
+
+        var errors = (new GccOutputParser()).parse(buildOutputStr);
         return errors.map((error) => {
             var aceAnnotationType;
 
             // Determine the type of editor annotation. ace supports error, warning or info.
-            if (error.gccErrorType.toLowerCase().indexOf('error') !== -1) {
+            if (error.buildErrorType.toLowerCase().indexOf('error') !== -1) {
                 aceAnnotationType = 'error';
-            } else if (error.gccErrorType.toLowerCase().indexOf('warning') !== -1) {
+            } else if (error.buildErrorType.toLowerCase().indexOf('warning') !== -1) {
                 aceAnnotationType = 'warning';
             } else {
                 aceAnnotationType = 'info';
@@ -203,11 +209,13 @@ class SysRuntime {
 
             return {
                 // line numbers in ace start from zero
+                workingDir: workingDir,
                 row: error.row - 1,
                 col: error.col,
-                isGccOptsError: error.type === 'gcc',
+                isBuildCmdError: (error.type === 'gcc') || (error.type == 'make'),
                 type: aceAnnotationType,
-                text: error.text
+                text: error.text,
+                file: error.file
             };
         });
     }

--- a/test/app/gcc-output-parser.js
+++ b/test/app/gcc-output-parser.js
@@ -30,7 +30,7 @@ describe('GccOutputParser', function () {
             expect(this.results.length).toEqual(1); // one error
             expect(this.results[0]).toEqual(jasmine.objectContaining({
                 column: 2,
-                gccErrorType: 'error',
+                buildErrorType: 'error',
                 row: 6,
                 text: 'expected \';\' before \'return\'',
                 type: 'compile'
@@ -54,9 +54,9 @@ describe('GccOutputParser', function () {
             // error one
             expect(this.results[0]).toEqual(jasmine.objectContaining({
                 column: 0,
-                /* TODO: currently the gccErrorType returned is incorrect,
+                /* TODO: currently the buildErrorType returned is incorrect,
                    but functionality is not affected */
-                //gccErrorType: 'error',
+                //buildErrorType: 'error',
                 row: 0,
                 text: 'undefined reference to \'nonExistentFunction\'',
                 type: 'compile'
@@ -65,7 +65,7 @@ describe('GccOutputParser', function () {
             // error two
             expect(this.results[1]).toEqual(jasmine.objectContaining({
                 column: 0,
-                gccErrorType: 'error',
+                buildErrorType: 'error',
                 row: 0,
                 text: 'ld returned 1 exit status',
                 type: 'linker'
@@ -85,7 +85,7 @@ describe('GccOutputParser', function () {
             expect(this.results.length).toEqual(1); // one error
             expect(this.results[0]).toEqual(jasmine.objectContaining({
                 column: 0,
-                gccErrorType: 'error',
+                buildErrorType: 'error',
                 row: 0,
                 text: 'unrecognized command line option \'-asdfasdf\'',
                 type: 'gcc'
@@ -105,7 +105,7 @@ describe('GccOutputParser', function () {
             expect(this.results.length).toEqual(1); // one error
             expect(this.results[0]).toEqual(jasmine.objectContaining({
                 column: 0,
-                gccErrorType: 'error',
+                buildErrorType: 'error',
                 row: 0,
                 text: 'unrecognised debug output level "aslkdfjalksjd"',
                 type: 'gcc'
@@ -131,7 +131,7 @@ describe('GccOutputParser', function () {
             // error one
             expect(this.results[0]).toEqual(jasmine.objectContaining({
                 column: 5,
-                gccErrorType: 'warning',
+                buildErrorType: 'warning',
                 row: 10,
                 text: 'return makes integer from pointer without a cast [enabled by default]',
                 type: 'compile'
@@ -140,7 +140,7 @@ describe('GccOutputParser', function () {
             // error two
             expect(this.results[1]).toEqual(jasmine.objectContaining({
                 column: 1,
-                gccErrorType: 'error',
+                buildErrorType: 'error',
                 row: 11,
                 text: 'expected \';\' before \'}\' token',
                 type: 'compile'


### PR DESCRIPTION
Adding error detection for makefiles and multiple files

==Features Added==
- Errors are now annotated on makefiles
- Errors on files are annotated for the most recent build until built again
- Errors on annotated on multiple files
- Errors remain on files even when navigated away and back again
- Changed Ace Editor's tabbing to hard tabs for supporting makefiles
- Temporarily disabled auto-indenting because it was removing annotations after half a second and indenting non-C files
