### PR TITLE
Fix disabled "backspace" key in input forms on playground

### DIFF
--- a/src/components/playground-layout/playground-layout.js
+++ b/src/components/playground-layout/playground-layout.js
@@ -34,6 +34,12 @@ class PlaygroundLayout {
                 backspace: 8
             };
 
+            // allow backspace for inputs
+            var focused = $(':focus');
+            if (focused.is('input') || focused.is('textarea')) {
+                return true;
+            }
+
             if (e.keyCode === keyCode.backspace) {
                 e.preventDefault();
             }


### PR DESCRIPTION
Some custom input forms created or future custom `input` and `textarea` parts should be allowed to use `backspace` key.
