### PR TITLE
Improve "program.c" consistency

### DIFF
--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -1,3 +1,4 @@
+/* global Buffer */
 import ko from 'knockout';
 import templateMarkup from 'text!./file-browser.html';
 import 'knockout-projections';

--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -110,6 +110,12 @@ class Filebrowser {
 
             // refresh the file browser on file system changes
             fs.addChangeListener(() => {
+                try {
+                    fs.readFileSync(this.activePath);
+                } catch (e) {
+                    this.makeActive(null);
+                    this.editor.setFile('', '', '');
+                }
                 setTimeout(() => {
                     this.refresh();
                 }, 300);
@@ -139,8 +145,6 @@ class Filebrowser {
                     }
                 }
             });
-
-
 
             // Save Hotkey
             this.editor.addKeyboardCommand(
@@ -298,7 +302,12 @@ class Filebrowser {
                 }
             });
 
-
+            // make program.c if not exists
+            try {
+                fs.readFileSync('/program.c');
+            } catch (e) {
+                fs.writeFile('/program.c', new Buffer(this.editor.getText(), 'binary'));
+            }
 
             // init
             this.init();
@@ -495,6 +504,8 @@ class Filebrowser {
         }
         else {
             this.activePath = '';
+            SysGlobalObservables.currentFileName('untitled');
+            SysGlobalObservables.currentFilePath('');
         }
     }
 


### PR DESCRIPTION
[Case 1]
Q: When user first uses the site, automatically load program.c? what is shown during boot?
A: Default “Hello world” code is shown. After loading, it shows the real “program.c” content.

[Case 2] 
Q: When a user deleted program.c and return to the site
A: It creates “program.c” with default hello world code when there is no “program.c”

[Case 3]
Q: Insure errors are not thrown when saving a file open in editor after it’s deleted, or saving program.c before it exists
A: When current editing file is removed, the editor content becomes empty and not able to save it. It goes to void file “Untitled”. So download that will make the file called “untitled” with empty content.
