### PR TITLE
sync editor content with file changes in terminal

### DIFF
--- a/src/app/sys-filesystem.js
+++ b/src/app/sys-filesystem.js
@@ -311,7 +311,7 @@ class SysFileSystem {
         console.log('Writting to local: ' + filename);
         var buf = new Buffer(file.data);
         this.localFS.writeFileSync(filename, buf, {mode:file.mode});
-
+        this.notifyChangeListeners();
     }
 
 

--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -102,7 +102,8 @@ class Filebrowser {
             // refresh the file browser on file system changes
             fs.addChangeListener(() => {
                 try {
-                    fs.readFileSync(this.activePath);
+                    var content = fs.readFileSync(this.activePath).toString('binary');
+                    this.editor.setFile(this.activePath, this.metaDataPathLookUp[this.activePath].name, content);
                 } catch (e) {
                     this.makeActive(null);
                     this.editor.setFile('', '', '');


### PR DESCRIPTION
When a file is modified with Vim or Nano editor through terminal, the changes were not applied to the working editor.

Now it applies the changes, when there are some changes made in editor.