### PR TITLE
Move GitHub UI to the Context Menu

### DIFF
--- a/src/app/sys-filesystem.js
+++ b/src/app/sys-filesystem.js
@@ -167,13 +167,13 @@ class SysFileSystem {
     * of all nodes within /home/user. Partially ordered from root -> leafs
     */
     getDirectoryTree(){
-        return this.getDirectoryTreeHelper('/');
+        return this.getDirectoryTreeOfDir('/');
     }
 
     /*
     * Helper for getDirectoryTree
     */
-    getDirectoryTreeHelper(path){
+    getDirectoryTreeOfDir(path){
         var children = this.localFS.readdirSync(path);
 
         if(path=='/')
@@ -200,7 +200,7 @@ class SysFileSystem {
 
         for(var a=0; a<dirs.length; a++)
         {
-            ret.push.apply(ret, this.getDirectoryTreeHelper(dirs[a]));
+            ret.push.apply(ret, this.getDirectoryTreeOfDir(dirs[a]));
         }
 
         return ret;

--- a/src/app/sys-global-observables.js
+++ b/src/app/sys-global-observables.js
@@ -6,10 +6,6 @@ export var compileStatus = ko.observable('');
 export var focusTerm = ko.observable((tty) => {});
 export var runCode = ko.observable((gccOptions) => {});
 
-export var githubUsername = ko.observable('');
-export var githubPassword = ko.observable('');
-export var githubRepo = ko.observable('');
-
 export var buildCmd = ko.observable('');
 export var execCmd = ko.observable('');
 

--- a/src/components/file-browser/file-browser.html
+++ b/src/components/file-browser/file-browser.html
@@ -4,43 +4,4 @@
         </ul>
     </div>
     <div id="file-browser-body"><span class="loading">Loading...</span></div>
-    <div id="github-opts-container">
-        <div class="row">
-            <div class="col-sm-9">
-                <div class="row">
-                    <label class="col-sm-2 control-label"><small>username</small></label>
-                    <div class="col-sm-4">
-                        <input class="form-control input-sm" type="text" maxlen=256
-                        title="Github username" data-bind="textInput: githubUsername">
-                    </div>
-                    <label class="col-sm-2 control-label"><small>password</small></label>
-                    <div class="col-sm-4">
-                        <input id="githubPassword" class="form-control input-sm" type="password" maxlen=256
-                        title="Github password" data-bind="textInput: githubPassword">
-                    </div>
-                </div>
-                <div class="row">
-                    <label class="col-sm-2 control-label"><small>repo&nbsp;url</small></label>
-                    <div class="col-sm-10">
-                        <input id="githubRepo" class="form-control input-sm" type="text" maxlen=256 title="URL of repo to clone into workspace" placeholder="username/saved-jor1k-workspace"
-                        data-bind="textInput: githubRepo">
-                    </div>
-                </div>
-            </div>
-            <div>
-                <button id="save-workspace-btn"
-                        data-bind="enable: compileBtnEnable"
-                        title="push workspace to 'saved-jor1k-workspace' repo"
-                        type="button" class="btn btn-xs pull-right col-sm-3 btn-default">
-                        Save Workspace<br>
-                </button>
-                <button id="clone-repo-btn"
-                        data-bind="enable: compileBtnEnable"
-                        title="clone repo into workspace"
-                        type="button" class="btn btn-xs pull-right col-sm-3 btn-default">
-                        Clone Repo<br>
-                </button>
-            </div>
-        </div>
-    </div>
 </div>

--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -30,65 +30,6 @@ var confirmNotific8Options = {
 
 class Filebrowser {
     constructor() {
-        this.githubUsername = SysGlobalObservables.githubUsername;
-        this.githubPassword = SysGlobalObservables.githubPassword;
-        this.githubRepo = SysGlobalObservables.githubRepo;
-        this.compileBtnEnable = SysGlobalObservables.compileBtnEnable;
-
-        var githubOptsContainer = $('#github-opts-container');
-        $('span:contains("File Browser")').click(() => {
-            githubOptsContainer.show();
-        });
-
-        $('span:contains("Code")').click(() => {
-            githubOptsContainer.hide();
-        });
-
-        $('span:contains("Video Search")').click(() => {
-            githubOptsContainer.hide();
-        });
-
-        $('span:contains("Man page search")').click(() => {
-            githubOptsContainer.hide();
-        });
-
-        githubOptsContainer.css('width', $('#code-container').width() + 'px');
-
-        const $saveReop = $('#save-workspace-btn');
-        $saveReop.click(() => {
-            var username = this.githubUsername();
-            var password = this.githubPassword();
-            console.log('Save Repo');
-            this.githubPassword('');
-
-            if (!username || !password)
-                return;
-
-            var github = new GithubInt(username, password);
-            github.saveAll();
-        });
-
-        const $cloneRepo = $('#clone-repo-btn');
-        $cloneRepo.click(() => {
-            var username = this.githubUsername();
-            var password = this.githubPassword();
-            var repo = this.githubRepo();
-            console.log('Clone Repo');
-            if (!repo)
-                return;
-
-            this.githubPassword('');
-
-            var github;
-
-            if(username && password)
-                github = new GithubInt(username, password);
-            else
-                github = new GithubInt();
-
-            github.cloneRepo(repo);
-        });
-
         var readyCallback = () => {
             this.id = '#file-browser-body';
             var fs = this.fs = SysFileSystem;
@@ -169,6 +110,10 @@ class Filebrowser {
                     }
                     menuHtml += '<li><a data-action="rename">Rename</a></li>';
                     menuHtml += '<li><a data-action="delete">Delete</a></li>';
+                    if (self.metaData[itemId].isDirectory) {
+                        menuHtml += '<li><a data-action="clone">Clone a repo into \'' + self.metaData[itemId].name + '\'...</a></li>';
+                        menuHtml += '<li><a data-action="push">Push \''+ self.metaData[itemId].name + '\' to a repo...</a></li>';
+                    }
 
                     menuContainer.html(menuHtml);
                 },
@@ -182,7 +127,7 @@ class Filebrowser {
                     var index;
 
                     if (action === 'delete') {
-                        bootbox.confirm('Are you sure you want to delete "' + itemName + '" ?', function (result) {
+                        bootbox.confirm('Are you sure you want to delete the directory \'' + itemName + '\'?', function (result) {
                             if (result) {
                                 if (self.metaData[itemId].isDirectory) {
                                     self.fs.removeDirectory(itemPath);
@@ -233,6 +178,98 @@ class Filebrowser {
                                     self.fs.writeFile(itemPath + '/' + result, '');
                                 }
                             }
+                        });
+                    }
+                    else if (action === 'clone') {
+                        bootbox.dialog({
+                            title: 'Clone a GitHub repo into \'' + itemName + '\'...',
+                            message: '<div>'
+                                +    '<div class="row">'
+                                +        '<label class="col-sm-2 control-label"><small>Username (optional)</small></label>'
+                                +        '<div class="col-sm-4">'
+                                +            '<input id="githubUsername" class="form-control input-sm" type="text" maxlen=256>'
+                                +        '</div>'
+                                +        '<label class="col-sm-2 control-label"><small>Password</small></label>'
+                                +        '<div class="col-sm-4">'
+                                +            '<input id="githubPassword" class="form-control input-sm" type="password" maxlen=256>'
+                                +        '</div>'
+                                +    '</div>'
+                                +    '<div class="row">'
+                                +        '<label class="col-sm-2 control-label"><small>Repo URI</small></label>'
+                                +        '<div class="col-sm-10">'
+                                +            '<input id="githubRepo" class="form-control input-sm" type="text" maxlen=256 placeholder="username/repo-name">'
+                                +        '</div>'
+                                +    '</div>'
+                                +'</div>',
+                            buttons: {
+                                success: {
+                                    label: "Clone",
+                                    className: "btn-clone",
+                                    callback: function () {
+                                        var username = $('#githubUsername').val();
+                                        var password = $('#githubPassword').val();
+                                        var repoName = $('#githubRepo').val();
+
+                                        console.log('Clone Repo');
+
+                                        if (repoName.trim().length === 0)
+                                            return;
+
+                                        var github;
+
+                                        if((username.trim().length !== 0) && (password.trim().length !== 0))
+                                            github = new GithubInt(username, password);
+                                        else
+                                            github = new GithubInt();
+
+                                        github.cloneRepo(repoName, itemPath);      
+                                    }
+                                }
+                            }   
+                        });
+                    }
+                    else if (action === 'push') {
+                        bootbox.dialog({
+                            title: 'Push \''+ itemName + '\' to a GitHub repo...',
+                            message: '<div>'
+                                +    '<div class="row">'
+                                +        '<label class="col-sm-2 control-label"><small>Username</small></label>'
+                                +        '<div class="col-sm-4">'
+                                +            '<input id="githubUsername" class="form-control input-sm" type="text" maxlen=256>'
+                                +        '</div>'
+                                +        '<label class="col-sm-2 control-label"><small>Password</small></label>'
+                                +        '<div class="col-sm-4">'
+                                +            '<input id="githubPassword" class="form-control input-sm" type="password" maxlen=256>'
+                                +        '</div>'
+                                +    '</div>'
+                                +    '<div class="row">'
+                                +        '<label class="col-sm-2 control-label"><small>Repo Name</small></label>'
+                                +        '<div class="col-sm-10">'
+                                +            '<input id="githubSaveRepo" class="form-control input-sm" type="text" maxlen=256 placeholder="sysprog-save">'
+                                +        '</div>'
+                                +    '</div>'
+                                +'</div>',
+                            buttons: {
+                                success: {
+                                    label: "Push",
+                                    className: "btn-push",
+                                    callback: function () {
+                                        var username = $('#githubUsername').val();
+                                        var password = $('#githubPassword').val();
+                                        var saveRepoName = $('#githubSaveRepo').val();
+
+                                        console.log('Save Repo');
+
+                                        if ((username.trim().length === 0) || (password.trim().length === 0) 
+                                            || (saveRepoName.trim().length === 0))
+                                            return;
+
+                                        var github = new GithubInt(username, password);
+
+                                        github.saveAll(saveRepoName, itemPath);     
+                                    }
+                                }
+                            }   
                         });
                     }
                 }

--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -203,8 +203,8 @@ class Filebrowser {
                                 +'</div>',
                             buttons: {
                                 success: {
-                                    label: "Clone",
-                                    className: "btn-clone",
+                                    label: 'Clone',
+                                    className: 'btn-clone',
                                     callback: function () {
                                         var username = $('#githubUsername').val();
                                         var password = $('#githubPassword').val();
@@ -251,8 +251,8 @@ class Filebrowser {
                                 +'</div>',
                             buttons: {
                                 success: {
-                                    label: "Push",
-                                    className: "btn-push",
+                                    label: 'Push',
+                                    className: 'btn-push',
                                     callback: function () {
                                         var username = $('#githubUsername').val();
                                         var password = $('#githubPassword').val();

--- a/src/styles/_file-browser.scss
+++ b/src/styles/_file-browser.scss
@@ -7,6 +7,7 @@
     user-select: none;
     width: 100%;
     height: 100%;
+    overflow: auto;
 
     .loading {
         font-size: 16px;


### PR DESCRIPTION
The GitHub UI was out of place and needed to only be present when needed. Adding it to the context menu of the file browser was the most optimal solution as it allows for the greatest flexibility of workflow.

Functionalities added:
- The GitHub UI has been moved from the file browser body to the file browser context menu.
![image](https://cloud.githubusercontent.com/assets/6979249/14656056/fd9a988c-064a-11e6-96ca-e17692ef34db.png)

- User is able to push the contents of **any** workspace directory to a public repo and specify its name
- User is able to clone a repo into **any** directory within the workspace.