### PR TITLE
Files and directories are downloadable

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,8 @@
     "browserfs": "0.5.8",
     "bootstrap-contextmenu": "^0.3.4",
     "bootbox.js": "^4.4.0",
-    "github-api": "~0.10.7"
+    "github-api": "~0.10.7",
+    "Stuk/jszip": "3.0.0"
   },
   "devDependencies": {},
   "resolutions": {

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -32,6 +32,7 @@ require.config({
         "bootstrap-contextmenu":"bower_modules/bootstrap-contextmenu/bootstrap-contextmenu",
         "bootbox":              "bower_modules/bootbox.js/bootbox",
         "github-api":           "bower_modules/github-api/github",
+        "jszip":                "bower_modules/jszip/dist/jszip.min",
 
         // Application-specific modules
         "app/config":           "app/config/config.dev", // overridden to 'config.dist' in build config

--- a/src/components/editor/editor.html
+++ b/src/components/editor/editor.html
@@ -9,7 +9,7 @@
                 <label class="control-label sr-only" for="editor-font-size">font size (in pixels)</label>
                 <input data-bind="value: prefs.fontSize" id="editor-font-size" type="number" class="form-control input-sm">
             </div>
-            <div class="col-md-2">
+            <div class="col-md-4">
                 <button id="current-code-btn" type="button" class="btn btn-default btn-sm center-block">
                     <span class="glyphicon glyphicon-file"></span> <span class="file-name" data-bind="text: currentFileName">untitled</span>
                 </button>
@@ -17,11 +17,6 @@
             <div class="col-md-2">
                 <button id="autoindent-code-btn" type="button" class="btn btn-default btn-sm center-block">
                     <span class="glyphicon glyphicon-indent-left"></span> Indent code
-                </button>
-            </div>
-            <div class="col-md-2">
-                <button id="download-file-btn" type="button" class="btn btn-default btn-sm center-block">
-                    <span class="glyphicon glyphicon-save"></span> Download file
                 </button>
             </div>
             <div class="col-md-2">

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -1,11 +1,9 @@
-/*global Bloodhound:false, saveAs:false*/
+/*global Bloodhound:false */
 import ko from 'knockout';
 import templateMarkup from 'text!./editor.html';
 import ace from 'ace/ace';
 import 'bloodhound';
 import TokenHighlighter from 'components/editor/token-highlighter';
-import 'Blob';
-import 'FileSaver';
 import * as SysGlobalObservables from 'app/sys-global-observables';
 
 class Editor {
@@ -41,12 +39,6 @@ class Editor {
         $('#editor-opts-container').find('form').submit((e) => {
             e.preventDefault();
             e.stopPropagation();
-        });
-
-        $('#download-file-btn').click(() => {
-            var text = this.getText();
-            var blob = new Blob([text]);
-            saveAs(blob, SysGlobalObservables.currentFileName());
         });
 
         $('#autoindent-code-btn').click(() => {

--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -1,4 +1,4 @@
-/* global Buffer */
+/*global Buffer, saveAs:false*/
 import ko from 'knockout';
 import templateMarkup from 'text!./file-browser.html';
 import 'knockout-projections';
@@ -212,7 +212,7 @@ class Filebrowser {
                                     zipNode.file(children[i].name, fileData);
                                 }
                             }
-                        }
+                        };
 
                         addChildren(zip, itemPath);
 


### PR DESCRIPTION
This addition makes the file browser the main source for downloading files and directories. Previously, users were only able to download the active file in the editor. The responsibly of this function has been moved to the file browser context menu.

Changes:
- The editor no longer contains the logic to download the active file, the button has been removed.
- Users can download files from the file browser context menu.
![image](https://cloud.githubusercontent.com/assets/6979249/14663237/367e8436-0684-11e6-91d5-6ae6c81a489c.png)

- Users can download entire directories as zips from the file browser context menu.
![image](https://cloud.githubusercontent.com/assets/6979249/14663226/176cc3e6-0684-11e6-81b2-b4542339ed61.png)
