### PR TITLE
Save active file on compile button

### DIFF
--- a/src/app/live-edit.js
+++ b/src/app/live-edit.js
@@ -71,6 +71,7 @@ class LiveEdit {
     }
 
     runCode(buildCmd) {
+		SysGlobalObservables.FileBrowser.saveActiveFile();
         var callback = this.processGccCompletion.bind(this);
         SysGlobalObservables.compileStatus('Compiling');
         this.runtime.startBuild(buildCmd, callback);

--- a/src/app/sys-global-observables.js
+++ b/src/app/sys-global-observables.js
@@ -22,3 +22,4 @@ export var compileBtnEnable = ko.observable('');
 export var projectLicense = ko.observable('');
 
 export var Editor = {};
+export var FileBrowser = {};

--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -104,7 +104,8 @@ class SysRuntime {
             statsid: 'vm-stats',  // element id for displaying VM statistics
             memorysize: 32, // in MB, must be a power of two
             path: jor1kBaseFsUrl, // kernelURL and fsURLs are relative to this path
-            worker: new Worker(jor1kWorkerUrl)
+            worker: new Worker(jor1kWorkerUrl),
+			relayURL: 'wss://relay.widgetry.org/'
         };
 
         this.jor1kgui = new Jor1k(jor1kparameters);

--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -38,6 +38,7 @@ class Filebrowser {
             var fs = this.fs = SysFileSystem;
 
             this.editor = SysGlobalObservables.Editor;
+			SysGlobalObservables.FileBrowser = this;
 
             this.depth = -1;
             this.directoryState = [];


### PR DESCRIPTION
This allows the use to edit a file and click 'Run' all unsaved changes in the active file will be saved.