### PR TITLE
Filesystem-int delete non-existing file fix

### DIFF
--- a/src/app/sys-filesystem.js
+++ b/src/app/sys-filesystem.js
@@ -289,11 +289,13 @@ class SysFileSystem {
                 this.notifyChangeListeners();
                 break;
             case 'delete':
-                if(this.localFS.statSync(path).isDirectory())
-                    this.localFS.rmdir(path, function(err){if(err)console.log(err);});
-                else
-                    if(this.localFS.existsSync(path))
+                if(this.localFS.existsSync(path))
+                {
+                    if(this.localFS.statSync(path).isDirectory())
+                        this.localFS.rmdir(path, function(err){if(err)console.log(err);});
+                    else
                         this.localFS.unlink(path, function(err){if(err)console.log(err);});
+                }
                 this.notifyChangeListeners();
                 break;
             case 'rename':
@@ -306,6 +308,8 @@ class SysFileSystem {
     }
 
     Jor1kReadCallBack(file){
+        if(file === null) return;
+
         var filename = file.name.substring('home/user'.length, file.name.length);
 
         console.log('Writting to local: ' + filename);


### PR DESCRIPTION
Fix odd case where the VM would quickly create a file then delete it. Race condition where the browser filesystem does not have enough time to create a local file before the VM notifies the browser file system to delete it. Fixed by null checking and re-ordering logic.