### PR TITLE
Initialize /dev/urandom in TTY1 before user control

### DIFF
--- a/src/app/sys-runtime.js
+++ b/src/app/sys-runtime.js
@@ -70,7 +70,7 @@ class SysRuntime {
 
         var onTTY1Login = (completed) => {
             if (completed) {
-                this.sendKeys('tty1', 'stty -clocal crtscts -ixoff\necho boot2ready-$?\n', 'boot2ready-0', onTTY1RootLogin);
+                this.sendKeys('tty1', 'head -c1 /dev/urandom\nstty -clocal crtscts -ixoff\necho boot2ready-$?\n', 'boot2ready-0', onTTY1RootLogin);
             }
         };
 


### PR DESCRIPTION
Internally, gcc reads bits from /dev/urandom. So on the first compile, a user would see:
![image](https://cloud.githubusercontent.com/assets/6979249/14798875/4bda0f56-0aff-11e6-8557-821327c9484c.png)
This is not ideal, so to silence this (place in boot sequence) we execute "head -c1 /dev/urandom" in TTY1 to initialize urandom. 
 