### PR TITLE
GitHub prompt on push to overwrite or merge with current

### DIFF
--- a/src/app/github-int/github-int.js
+++ b/src/app/github-int/github-int.js
@@ -2,7 +2,7 @@
 import SysFileSystem from 'app/sys-filesystem';
 import { notify } from 'app/notifications';
 import * as Github from 'github-api';
-
+import bootbox from 'bootbox';
 
 class GithubInt {
 
@@ -132,7 +132,38 @@ class GithubInt {
                 }
             }
             else{
-                repo.deleteRepo(this.createSaveRepo.bind(this));
+                bootbox.dialog({
+                    title: 'Careful!',
+                    message: 'A repo with the name \'' + saveRepoName + '\' already exists. What do you want to do?',
+                    buttons: {
+                        cancel: {
+                            label: 'Cancel',
+                            className: 'btn-default',
+                            callback: function () {
+                                return;
+                            }
+                        },
+                        merge: {
+                            label: 'Merge',
+                            className: 'btn-primary',
+                            callback: function () {
+                                var repo = this.hub.getRepo(this.username, this.saveRepoName);
+                                this.pushToRepo(repo, this.sourcePath);
+                            }.bind(this)
+                        },
+                        overwrite: {
+                            label: 'Overwrite',
+                            className: 'btn-danger',
+                            callback: function () {
+                                bootbox.confirm('Are you sure? All the contents of \'' + saveRepoName  + '\' will be overwritten.', function(result) {
+                                    if(result){
+                                        repo.deleteRepo(this.createSaveRepo.bind(this));
+                                    }
+                                }.bind(this)); 
+                            }.bind(this)
+                        }
+                    }
+                });
             }
 
         }.bind(this));

--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -245,7 +245,7 @@ class Filebrowser {
                             buttons: {
                                 success: {
                                     label: 'Clone',
-                                    className: 'btn-clone',
+                                    className: 'btn-primary',
                                     callback: function () {
                                         var username = $('#githubUsername').val();
                                         var password = $('#githubPassword').val();
@@ -293,7 +293,7 @@ class Filebrowser {
                             buttons: {
                                 success: {
                                     label: 'Push',
-                                    className: 'btn-push',
+                                    className: 'btn-primary',
                                     callback: function () {
                                         var username = $('#githubUsername').val();
                                         var password = $('#githubPassword').val();


### PR DESCRIPTION
If the user is 'pushing' a directory to a repo that already exists on their account, they will be prompted with the following:
![screen shot 2016-04-25 at 7 47 24 pm](https://cloud.githubusercontent.com/assets/6979249/14803376/9279e840-0b1e-11e6-9fee-a7bd2ec60801.png)

'**Cancel**': Closes the prompt and no further action is taken.
'**Merge**': Merges the directory's contents with the already existing repo. Files with the same path will be overwritten with the new content.
'**Overwrite**': The user is presented with a confirmation dialog to ensure this is the desired action as it is not reversible.
![screen shot 2016-04-25 at 7 50 03 pm](https://cloud.githubusercontent.com/assets/6979249/14803418/f01337cc-0b1e-11e6-8195-4eebcbd3739f.png) Confirming the action, the existing repo is deleted and the contents of the selected directory takes its place.
