### PR TITLE
Add modelist to build and denote supported syntax modes

### DIFF
--- a/gulp-tasks/build-js.js
+++ b/gulp-tasks/build-js.js
@@ -54,6 +54,7 @@ const requireJsOptimizerFilesConfig = [
             'components/compiler-state-label/compiler-state-label',
             'components/not-found-page/not-found-page',
             'components/file-browser/file-browser',
+            'ace/ext/modelist',
             'ace/mode/c_cpp',
             'ace/theme/monokai',
             'ace/theme/terminal',

--- a/gulp-tasks/build-js.js
+++ b/gulp-tasks/build-js.js
@@ -56,6 +56,7 @@ const requireJsOptimizerFilesConfig = [
             'components/file-browser/file-browser',
             'ace/ext/modelist',
             'ace/mode/c_cpp',
+            'ace/mode/makefile',
             'ace/theme/monokai',
             'ace/theme/terminal',
             'ace/theme/tomorrow',

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -21,6 +21,8 @@ class Editor {
 
         this.availableThemes = ko.observableArray(['monokai', 'terminal', 'tomorrow', 'xcode']);
 
+        this.supportedAceModes = ['ace/mode/c_cpp','ace/mode/makefile'];
+
         this.annotations = params.annotations;
         this.keyboardShortcuts = params.keyboardShortcuts;
 
@@ -260,7 +262,7 @@ class Editor {
 		this.filename = filename;
 		var mode = this.modelist.getModeForPath(filename).mode;
 
-        if(mode !== 'ace/mode/c_cpp')
+        if(this.supportedAceModes.indexOf(mode) < 0)
             mode = 'ace/mode/text';
 
 		this.aceEditor.session.setMode(mode);

--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -259,6 +259,10 @@ class Editor {
 		
 		this.filename = filename;
 		var mode = this.modelist.getModeForPath(filename).mode;
+
+        if(mode !== 'ace/mode/c_cpp')
+            mode = 'ace/mode/text';
+
 		this.aceEditor.session.setMode(mode);
 
         return;


### PR DESCRIPTION
Since the ace editor now supports more than just c/cpp files it needs access to the list of supported files -- this is contained in "ace/ext/modelist", so it is added to the build list. 
Support for makefiles has been added and also the logic to set ace highlighting mode to the correct mode (a supported mode) on file load.
**Note:** To add more nodes one would need to add the supported files to the build list contained in build-js.js and also specify the mode in the supportedAceModes list in editor.js. 