### PR TITLE
Synchronously load browserFS for non-chrome browser support

### DIFF
--- a/gulp-tasks/build-assets.js
+++ b/gulp-tasks/build-assets.js
@@ -8,7 +8,7 @@ gulp.task('html', () => {
     const indexHtml = gulp.src('./src/index.html')
         .pipe(htmlreplace({
             'css': 'styles.css',
-            'js': 'scripts.js'
+            'js': ['browserfs.min.js', 'scripts.js']
         }));
 
     const otherHtml = gulp.src('./src/404.html');

--- a/gulp-tasks/build-js.js
+++ b/gulp-tasks/build-js.js
@@ -97,3 +97,10 @@ gulp.task('js', ['js:optimize'], () => {
     // Now clean up
     return gulp.src('./temp', { read: false }).pipe(clean());
 });
+
+// Copy BrowserFS for synchronous loading
+gulp.task('js:browserFS', () => {
+   // Copy From Bower components to Dist Folder
+   return gulp.src('./src/bower_modules/browserfs/dist/browserfs.min.js')
+        .pipe(gulp.dest('./dist/')); 
+});

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -25,7 +25,7 @@ gulp.task('clean', () => {
         .pipe(clean());
 });
 
-gulp.task('build', ['lint', 'html', 'js', 'css:dist', 'fonts', 'images', 'extras'], () => {
+gulp.task('build', ['lint', 'html', 'js', 'js:browserFS', 'css:dist', 'fonts', 'images', 'extras'], () => {
     console.log('\nPlaced optimized files in ' + chalk.magenta('dist/\n'));
     const buildStampFile = 'dist/build-stamp.txt';
     const recentCommitsFile = 'dist/publish-recentcommits.txt';

--- a/src/app/require.config.js
+++ b/src/app/require.config.js
@@ -28,7 +28,6 @@ require.config({
         "bloodhound":           "bower_modules/typeahead.js/dist/bloodhound.min", // exports window global "Bloodhound"
         "FileSaver":            "bower_modules/FileSaver/FileSaver.min", // exports window global "saveAs"
         "Blob":                 "bower_modules/Blob/Blob", // exports window global "Blob"
-        "browserfs":            "bower_modules/browserfs/dist/browserfs.min",
         "bootstrap-contextmenu":"bower_modules/bootstrap-contextmenu/bootstrap-contextmenu",
         "bootbox":              "bower_modules/bootbox.js/bootbox",
         "github-api":           "bower_modules/github-api/github",

--- a/src/app/sys-filesystem.js
+++ b/src/app/sys-filesystem.js
@@ -1,6 +1,4 @@
-/* global require, Buffer */
-import BrowserFS from 'browserfs';
-
+/* global require, Buffer, BrowserFS */
 class SysFileSystem {
 
     constructor() {

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,7 @@
       <link href="styles.css" rel="stylesheet">
     <!-- endbuild -->
     <!-- build:js -->
+      <script src="bower_modules/browserfs/dist/browserfs.min.js"></script>
       <script src="bower_modules/requirejs/require.js"></script>
       <script>
       require(['app/require.config'], function () {


### PR DESCRIPTION
The module needs to be loaded before the document is loaded or else it will overwrite it. 
The problem is that requirejs loads the module after the document is loaded.

I pulled out the browserFS module from RequireJS to separate module to resolve this problem.