### PR TITLE
Disallow rename and delete of home dir

### DIFF
--- a/src/components/file-browser/file-browser.js
+++ b/src/components/file-browser/file-browser.js
@@ -112,8 +112,10 @@ class Filebrowser {
                         menuHtml += '<li><a data-action="newFile">New File</a></li>';
                         menuHtml += '<li><a data-action="newDir">New Directory</a></li>';
                     }
-                    menuHtml += '<li><a data-action="rename">Rename</a></li>';
-                    menuHtml += '<li><a data-action="delete">Delete</a></li>';
+                    if (self.metaData[itemId].path != '') {
+                        menuHtml += '<li><a data-action="rename">Rename</a></li>';
+                        menuHtml += '<li><a data-action="delete">Delete</a></li>';
+                    }
                     if (!self.metaData[itemId].isDirectory) {
                         menuHtml += '<li><a data-action="downloadFile">Download \''+ self.metaData[itemId].name +'\'</a></li>';
                     }


### PR DESCRIPTION
The file browser should not allow deleting or renaming of the home directory.